### PR TITLE
Disallow stdlib functions that print to stdio

### DIFF
--- a/.github/lint-disallowed-functions-in-library.sh
+++ b/.github/lint-disallowed-functions-in-library.sh
@@ -4,7 +4,7 @@ set -e
 # Disallow usages of functions that cause the program to exit in the library code
 SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 EXCLUDE_DIRECTORIES="--exclude-dir=examples --exclude-dir=.git --exclude-dir=.github "
-DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(')
+DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(' 'fmt.Println(' 'fmt.Printf(' 'log.Print(' 'log.Println(' 'log.Printf(')
 
 
 for disallowedFunction in "${DISALLOWED_FUNCTIONS[@]}"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Sean DuBois](https://github.com/Sean-Der) - *Linter fixes*
 * [adwpc](https://github.com/adwpc) - *Fix PictureLossIndication Unmarshal error*
 * [Luke Curley](https://github.com/kixelated)
+* [Hugo Arregui](https://github.com/hugoArregui)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/doc.go
+++ b/doc.go
@@ -20,11 +20,11 @@ Decoding RTCP packets:
 	for _, pkt := range packets {
 		switch p := pkt.(type) {
 		case *rtcp.ReceptionReport:
-			fmt.Println("RR", p)
+			...
 		case *rtcp.SenderReport:
-			fmt.Println("SR", p)
+			...
 		default:
-			fmt.Println(p)
+			...
 		}
 	}
 


### PR DESCRIPTION
All printing to stdio must be done via pion/logging, all calls to common printing functions will not cause CI to fail

Relates to https://github.com/pion/webrtc/issues/361