### PR TITLE
Change Umarshal return type to []Packet

### DIFF
--- a/compound_packet.go
+++ b/compound_packet.go
@@ -66,6 +66,27 @@ func (c CompoundPacket) Validate() error {
 	return errMissingCNAME
 }
 
+//CNAME returns the CNAME that *must* be present in every CompoundPacket
+func (c CompoundPacket) CNAME() (string, error) {
+	if len(c) < 1 {
+		return "", errEmptyCompound
+	}
+
+	for _, pkt := range c[1:] {
+		sdes, ok := pkt.(*SourceDescription)
+		if ok {
+			for _, c := range sdes.Chunks {
+				for _, it := range c.Items {
+					if it.Type == SDESCNAME {
+						return it.Text, nil
+					}
+				}
+			}
+		}
+	}
+	return "", errMissingCNAME
+}
+
 // Marshal encodes the CompoundPacket as binary.
 func (c CompoundPacket) Marshal() ([]byte, error) {
 	if err := c.Validate(); err != nil {

--- a/compound_packet.go
+++ b/compound_packet.go
@@ -100,15 +100,8 @@ func (c CompoundPacket) Marshal() ([]byte, error) {
 		return nil, err
 	}
 
-	out := make([]byte, 0)
-	for _, p := range c {
-		data, err := p.Marshal()
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, data...)
-	}
-	return out, nil
+	p := []Packet(c)
+	return Marshal(p)
 }
 
 // Unmarshal decodes a CompoundPacket from binary.

--- a/compound_packet.go
+++ b/compound_packet.go
@@ -68,6 +68,8 @@ func (c CompoundPacket) Validate() error {
 
 //CNAME returns the CNAME that *must* be present in every CompoundPacket
 func (c CompoundPacket) CNAME() (string, error) {
+	var err error
+
 	if len(c) < 1 {
 		return "", errEmptyCompound
 	}
@@ -78,9 +80,14 @@ func (c CompoundPacket) CNAME() (string, error) {
 			for _, c := range sdes.Chunks {
 				for _, it := range c.Items {
 					if it.Type == SDESCNAME {
-						return it.Text, nil
+						return it.Text, err
 					}
 				}
+			}
+		} else {
+			_, ok := pkt.(*ReceiverReport)
+			if !ok {
+				err = errPacketBeforeCNAME
 			}
 		}
 	}

--- a/compound_packet_test.go
+++ b/compound_packet_test.go
@@ -29,22 +29,25 @@ func TestBadCompound(t *testing.T) {
 	badcompound = realPacket[84:104]
 
 	packets, err = Unmarshal(badcompound)
+	assert.NoError(t, err)
+
+	compound := CompoundPacket(packets)
+
+	//This shouldn't validate correctly...
+	err = compound.Validate()
+
 	if got, want := err, errBadFirstPacket; got != want {
 		t.Fatalf("Unmarshal(badcompound) err=%v, want %v", got, want)
 	}
-	compound, ok := packets.(*CompoundPacket)
-	if !ok {
-		t.Fatalf("Unmarshal(badcompound) result=%#v, want CompoundPacket", packets)
-	}
 
-	if got, want := len(*compound), 2; got != want {
+	if got, want := len(compound), 2; got != want {
 		t.Fatalf("Unmarshal(badcompound) len=%d, want %d", got, want)
 	}
-	if _, ok := (*compound)[0].(*Goodbye); !ok {
-		t.Fatalf("Unmarshal(badcompound); first packet = %#v, want Goodbye", (*compound)[0])
+	if _, ok := compound[0].(*Goodbye); !ok {
+		t.Fatalf("Unmarshal(badcompound); first packet = %#v, want Goodbye", compound[0])
 	}
-	if _, ok := (*compound)[1].(*PictureLossIndication); !ok {
-		t.Fatalf("Unmarshal(badcompound); second packet = %#v, want PictureLossIndication", (*compound)[1])
+	if _, ok := compound[1].(*PictureLossIndication); !ok {
+		t.Fatalf("Unmarshal(badcompound); second packet = %#v, want PictureLossIndication", compound[1])
 	}
 }
 

--- a/packet.go
+++ b/packet.go
@@ -15,7 +15,7 @@ type Packet interface {
 // If this is a reduced-size RTCP packet a feedback packet (Goodbye, SliceLossIndication, etc)
 // will be returned. Otherwise, the underlying type of the returned packet will be
 // CompoundPacket.
-func Unmarshal(rawData []byte) (Packet, error) {
+func Unmarshal(rawData []byte) ([]Packet, error) {
 	var packets []Packet
 	for len(rawData) != 0 {
 		p, processed, err := unmarshal(rawData)
@@ -32,16 +32,9 @@ func Unmarshal(rawData []byte) (Packet, error) {
 	// Empty packet
 	case 0:
 		return nil, errInvalidHeader
-	// Reduced-size RTCP (RFC 5506)
-	case 1:
-		return packets[0], nil
-	// CompoundPacket
+	// Multiple Packets
 	default:
-		p := CompoundPacket(packets)
-		if err := p.Validate(); err != nil {
-			return &p, err
-		}
-		return &p, nil
+		return packets, nil
 	}
 }
 

--- a/packet.go
+++ b/packet.go
@@ -38,6 +38,20 @@ func Unmarshal(rawData []byte) ([]Packet, error) {
 	}
 }
 
+//Marshal takes an array of Packets and serializes them to a single buffer
+func Marshal(packets []Packet) ([]byte, error) {
+	out := make([]byte, 0)
+	for _, p := range packets {
+		data, err := p.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, data...)
+	}
+	return out, nil
+
+}
+
 // unmarshal is a factory which pulls the first RTCP packet from a bytestream,
 // and returns it's parsed representation, and the amount of data that was processed.
 func unmarshal(rawData []byte) (packet Packet, bytesprocessed int, err error) {

--- a/packet_test.go
+++ b/packet_test.go
@@ -74,7 +74,7 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("Error unmarshalling packets: %s", err)
 	}
 
-	expected := &CompoundPacket{
+	expected := []Packet{
 		&ReceiverReport{
 			SSRC: 0x902f9e2e,
 			Reports: []ReceptionReport{{


### PR DESCRIPTION
#### Description
this puts the onus of RTCP packet validation downstream, but in certain cases (rtcp-rsize), that validation should be skipped anyway.

#### Reference issue
Fixes #29 
