### PR TITLE
Add bounds checking to unmarshal

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -63,6 +63,9 @@ func unmarshal(rawData []byte) (packet Packet, bytesprocessed int, err error) {
 	}
 
 	bytesprocessed = int(h.Length+1) * 4
+	if bytesprocessed > len(rawData) {
+		return nil, 0, errPacketTooShort
+	}
 	inPacket := rawData[:bytesprocessed]
 
 	switch h.Type {

--- a/packet_test.go
+++ b/packet_test.go
@@ -123,3 +123,16 @@ func TestUnmarshalNil(t *testing.T) {
 		t.Fatalf("Unmarshal(nil) err = %v, want %v", got, want)
 	}
 }
+
+func TestInvalidHeaderLength(t *testing.T) {
+	var invalidPacket = []byte{
+		// Receiver Report (offset=0)
+		// v=2, p=0, count=1, RR, len=100
+		0x81, 0xc9, 0x0, 0x64,
+	}
+
+	_, err := Unmarshal(invalidPacket)
+	if got, want := err, errPacketTooShort; got != want {
+		t.Fatalf("Unmarshal(nil) err = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Return error (instead of panic'ing) when we get a RTCP packet
with an invalid length

Fixes the following test crash
```
--- FAIL: TestInvalidHeaderLength (0.00s)
panic: runtime error: slice bounds out of range [recovered]
        panic: runtime error: slice bounds out of range

goroutine 30 [running]:
testing.tRunner.func1(0xc000132d00)
        /usr/local/Cellar/go/1.12.6/libexec/src/testing/testing.go:830 +0x392
panic(0x12eda00, 0x15b8460)
        /usr/local/Cellar/go/1.12.6/libexec/src/runtime/panic.go:522 +0x1b5
github.com/pion/rtcp.unmarshal(0xc0000be9b0, 0x4, 0x4, 0x0, 0x141e810, 0xe, 0x1589c07, 0x3b)
        /Users/seaduboi/go/src/github.com/pion/rtcp/packet.go:69 +0x334
github.com/pion/rtcp.Unmarshal(0xc0000be9b0, 0x4, 0x4, 0x139ea361ab101, 0x100000001, 0xc000030f70, 0x104dd48, 0x139ea361ab101)
        /Users/seaduboi/go/src/github.com/pion/rtcp/packet.go:21 +0xb9
github.com/pion/rtcp.TestInvalidHeaderLength(0xc000132d00)
        /Users/seaduboi/go/src/github.com/pion/rtcp/packet_test.go:134 +0x67
testing.tRunner(0xc000132d00, 0x135ba88)
        /usr/local/Cellar/go/1.12.6/libexec/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
        /usr/local/Cellar/go/1.12.6/libexec/src/testing/testing.go:916 +0x35a
exit status 2
FAIL    github.com/pion/rtcp    0.445s
```