### PR TITLE
Fix transport layer cc large negative delta unmarshal

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Atsushi Watanabe](https://github.com/at-wat)
 * [Juliusz Chroboczek](https://github.com/jech)
 * [Gabor Pongracz](https://github.com/pongraczgabor87)
+* [Simone Gotti](https://github.com/sgotti)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/transport_layer_cc.go
+++ b/transport_layer_cc.go
@@ -273,7 +273,7 @@ func (r *RecvDelta) Unmarshal(rawPacket []byte) error {
 	}
 
 	r.Type = TypeTCCPacketReceivedLargeDelta
-	r.Delta = TypeTCCDeltaScaleFactor * int64(binary.BigEndian.Uint16(rawPacket))
+	r.Delta = TypeTCCDeltaScaleFactor * int64(int16(binary.BigEndian.Uint16(rawPacket)))
 	return nil
 }
 

--- a/transport_layer_cc_test.go
+++ b/transport_layer_cc_test.go
@@ -175,7 +175,8 @@ func TestTransportLayerCC_RecvDeltaUnmarshal(t *testing.T) {
 			Name: "small delta 63.75ms",
 			Data: []byte{0xFF},
 			Want: RecvDelta{
-				Type:  TypeTCCPacketReceivedSmallDelta,
+				Type: TypeTCCPacketReceivedSmallDelta,
+				// 255 * 250
 				Delta: 63750,
 			},
 			WantError: nil,
@@ -184,8 +185,19 @@ func TestTransportLayerCC_RecvDeltaUnmarshal(t *testing.T) {
 			Name: "big delta 8191.75ms",
 			Data: []byte{0x7F, 0xFF},
 			Want: RecvDelta{
-				Type:  TypeTCCPacketReceivedLargeDelta,
+				Type: TypeTCCPacketReceivedLargeDelta,
+				// 32767 * 250
 				Delta: 8191750,
+			},
+			WantError: nil,
+		},
+		{
+			Name: "big delta -8192ms",
+			Data: []byte{0x80, 0x00},
+			Want: RecvDelta{
+				Type: TypeTCCPacketReceivedLargeDelta,
+				// -32768 * 250
+				Delta: -8192000,
 			},
 			WantError: nil,
 		},
@@ -212,7 +224,8 @@ func TestTransportLayerCC_RecvDeltaMarshal(t *testing.T) {
 		{
 			Name: "small delta 63.75ms",
 			Data: RecvDelta{
-				Type:  TypeTCCPacketReceivedSmallDelta,
+				Type: TypeTCCPacketReceivedSmallDelta,
+				// 255 * 250
 				Delta: 63750,
 			},
 			Want:      []byte{0xFF},
@@ -221,10 +234,21 @@ func TestTransportLayerCC_RecvDeltaMarshal(t *testing.T) {
 		{
 			Name: "big delta 8191.75ms",
 			Data: RecvDelta{
-				Type:  TypeTCCPacketReceivedLargeDelta,
+				Type: TypeTCCPacketReceivedLargeDelta,
+				// 32767 * 250
 				Delta: 8191750,
 			},
 			Want:      []byte{0x7F, 0xFF},
+			WantError: nil,
+		},
+		{
+			Name: "big delta -8192ms",
+			Data: RecvDelta{
+				Type: TypeTCCPacketReceivedLargeDelta,
+				// -32768 * 250
+				Delta: -8192000,
+			},
+			Want:      []byte{0x80, 0x00},
 			WantError: nil,
 		},
 	} {


### PR DESCRIPTION
#### Description

Large deltas are signed. But unmarshal method doesn't correctly handle
them returning a bigger positive number due to direct casting to int64.

This patch fixes this issue and adds a related test.