### PR TITLE
Fixes transportcc padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Juliusz Chroboczek](https://github.com/jech)
 * [Gabor Pongracz](https://github.com/pongraczgabor87)
 * [Simone Gotti](https://github.com/sgotti)
+* [lllf](https://github.com/LittleLightLittleFire)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/transport_layer_cc_test.go
+++ b/transport_layer_cc_test.go
@@ -618,12 +618,7 @@ func TestTransportLayerCC_Marshal(t *testing.T) {
 				0x43, 0x3, 0x2f, 0xa0,
 				0x0, 0x99, 0x0, 0x1,
 				0x3d, 0xe8, 0x2, 0x17,
-				// change last byte '0b00000001' to '0b00000000', make ci pass
-				0x20, 0x1, 0x94, 0x0,
-				// 0b00100000, 0b00000001, 0b10010100, 0b00000001,
-				// the 'Want []byte' came from chrome, and
-				// the padding byte is '0b00000001', but i think should be '0b00000000' when i read the RFC, what's wrong?
-				// webrtc code: https://webrtc.googlesource.com/src/webrtc/+/f54860e9ef0b68e182a01edc994626d21961bc4b/modules/rtp_rtcp/source/rtcp_packet/transport_feedback.cc
+				0x20, 0x1, 0x94, 0x1,
 			},
 			WantError: nil,
 		},
@@ -673,12 +668,7 @@ func TestTransportLayerCC_Marshal(t *testing.T) {
 				0x1, 0x74, 0x0, 0x2,
 				0x45, 0xb1, 0x5a, 0x40,
 				0xd8, 0x0, 0xf0, 0xff,
-				// change last byte '0b00000011' to '0b00000000', make ci pass
-				0xd0, 0x0, 0x0, 0x0,
-				// 0b11010000, 0b00000000, 0b00000000, 0b00000011,
-				// the 'Want []byte' came from chrome, and
-				// the padding byte is '0b00000011', but i think should be '0b00000000' when i read the RFC
-				// webrtc code: https://webrtc.googlesource.com/src/webrtc/+/f54860e9ef0b68e182a01edc994626d21961bc4b/modules/rtp_rtcp/source/rtcp_packet/transport_feedback.cc
+				0xd0, 0x0, 0x0, 0x2,
 			},
 			WantError: nil,
 		},
@@ -809,7 +799,7 @@ func TestTransportLayerCC_Marshal(t *testing.T) {
 				0x10, 0x63, 0x6e, 0x1,
 				0x20, 0x7, 0x4c, 0x24,
 				0x24, 0x10, 0xc, 0xc,
-				0x10, 0x0, 0x0, 0x0,
+				0x10, 0x0, 0x0, 0x3,
 			},
 			WantError: nil,
 		},
@@ -861,7 +851,7 @@ func TestTransportLayerCC_Marshal(t *testing.T) {
 				0x0, 0x1, 0x0, 0xe,
 				0x10, 0x63, 0x6d, 0x0,
 				0xba, 0x0, 0x10, 0xc,
-				0xc, 0x10, 0x0, 0x0,
+				0xc, 0x10, 0x0, 0x2,
 			},
 			WantError: nil,
 		},

--- a/util.go
+++ b/util.go
@@ -1,7 +1,5 @@
 package rtcp
 
-import "fmt"
-
 // getPadding Returns the padding required to make the length a multiple of 4
 func getPadding(len int) int {
 	if len%4 == 0 {
@@ -30,16 +28,4 @@ func getNBitsFromByte(b byte, begin, n uint16) uint16 {
 // get24BitFromBytes get 24bits from `[3]byte` slice
 func get24BitsFromBytes(b []byte) uint32 {
 	return uint32(b[0])<<16 + uint32(b[1])<<8 + uint32(b[2])
-}
-
-// dumpBinary dump []byte to string
-func dumpBinary(b []byte) string {
-	out := ""
-	for i, v := range b {
-		out += fmt.Sprintf("0b%08b,", v)
-		if (i+1)%4 == 0 {
-			out += "\n"
-		}
-	}
-	return out
 }


### PR DESCRIPTION
If padding is set in the header, then the last octet of padding is set
to be the length of padding itself. This is consistent with the usage of
"zero padding" in SR.

> If the padding bit is set, this individual RTCP packet contains
> some additional padding octets at the end which are not part of
> the control information but are included in the length field.  The
> last octet of the padding is a count of how many padding octets
> should be ignored, including itself (it will be a multiple of
> four).

https://tools.ietf.org/html/rfc3550#section-6.4.1

#### Reference issue
Fixes #52
