### PR TITLE
Add sender_report's SSRC to DestinationSSRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Gabor Pongracz](https://github.com/pongraczgabor87)
 * [Simone Gotti](https://github.com/sgotti)
 * [lllf](https://github.com/LittleLightLittleFire)
+* [cnderrauber](https://github.com/cnderrauber)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/sender_report.go
+++ b/sender_report.go
@@ -219,10 +219,11 @@ func (r *SenderReport) Unmarshal(rawPacket []byte) error {
 
 // DestinationSSRC returns an array of SSRC values that this packet refers to.
 func (r *SenderReport) DestinationSSRC() []uint32 {
-	out := make([]uint32, len(r.Reports))
+	out := make([]uint32, len(r.Reports)+1)
 	for i, v := range r.Reports {
 		out[i] = v.SSRC
 	}
+	out[len(r.Reports)] = r.SSRC
 	return out
 }
 

--- a/sender_report_test.go
+++ b/sender_report_test.go
@@ -181,6 +181,19 @@ func TestSenderReportUnmarshal(t *testing.T) {
 		if got, want := sr, test.Want; !reflect.DeepEqual(got, want) {
 			t.Fatalf("Unmarshal %q sr: got %v, want %v", test.Name, got, want)
 		}
+
+		var ssrcFound bool
+		dstSsrc := sr.DestinationSSRC()
+		for _, v := range dstSsrc {
+			if v == sr.SSRC {
+				ssrcFound = true
+				break
+			}
+		}
+
+		if !ssrcFound {
+			t.Fatalf("Unmarshal %q sr: sr's DestinationSSRC should include it's SSRC field", test.Name)
+		}
 	}
 }
 


### PR DESCRIPTION
#### Description
Add sender_report's SSRC to DestinationSSRC
#### Reference issue
Fixes #...
If a sender report packet has no ReceptionReport, it's DestinationSSRC would return empty slice, can not be dispatch to rtcpReadStream.
