### PR TITLE
Add `String()` method to `Packet` interface

### DIFF
--- a/compound_packet.go
+++ b/compound_packet.go
@@ -1,5 +1,9 @@
 package rtcp
 
+import (
+	"strings"
+)
+
 // A CompoundPacket is a collection of RTCP packets transmitted as a single packet with
 // the underlying protocol (for example UDP).
 //
@@ -13,8 +17,6 @@ package rtcp
 //
 // Other RTCP packet types may follow in any order. Packet types may appear more than once.
 type CompoundPacket []Packet
-
-var _ Packet = (*CompoundPacket)(nil) // assert is a Packet
 
 // Validate returns an error if this is not an RFC-compliant CompoundPacket.
 func (c CompoundPacket) Validate() error {
@@ -133,4 +135,13 @@ func (c CompoundPacket) DestinationSSRC() []uint32 {
 	}
 
 	return c[0].DestinationSSRC()
+}
+
+func (c CompoundPacket) String() string {
+	out := "CompoundPacket\n"
+	for _, p := range c {
+		out += p.String()
+	}
+	out = strings.TrimSuffix(strings.ReplaceAll(out, "\n", "\n\t"), "\t")
+	return out
 }

--- a/compound_packet_test.go
+++ b/compound_packet_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var _ Packet = (*CompoundPacket)(nil) // assert is a Packet
+
 func TestReadEOF(t *testing.T) {
 	shortHeader := []byte{
 		0x81, 0xc9, // missing type & len

--- a/goodbye.go
+++ b/goodbye.go
@@ -2,6 +2,7 @@ package rtcp
 
 import (
 	"encoding/binary"
+	"fmt"
 )
 
 // The Goodbye packet indicates that one or more sources are no longer active.
@@ -11,8 +12,6 @@ type Goodbye struct {
 	// Optional text indicating the reason for leaving, e.g., "camera malfunction" or "RTP loop detected"
 	Reason string
 }
-
-var _ Packet = (*Goodbye)(nil) // assert is a Packet
 
 // Marshal encodes the Goodbye packet in binary
 func (g Goodbye) Marshal() ([]byte, error) {
@@ -142,5 +141,15 @@ func (g *Goodbye) len() int {
 func (g *Goodbye) DestinationSSRC() []uint32 {
 	out := make([]uint32, len(g.Sources))
 	copy(out, g.Sources)
+	return out
+}
+
+func (g Goodbye) String() string {
+	out := "Goodbye\n"
+	for i, s := range g.Sources {
+		out += fmt.Sprintf("\tSource %d: %x\n", i, s)
+	}
+	out += fmt.Sprintf("\tReason: %s\n", g.Reason)
+
 	return out
 }

--- a/goodbye_test.go
+++ b/goodbye_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+var _ Packet = (*Goodbye)(nil) // assert is a Packet
+
 func TestGoodbyeUnmarshal(t *testing.T) {
 	for _, test := range []struct {
 		Name      string

--- a/packet.go
+++ b/packet.go
@@ -7,6 +7,7 @@ type Packet interface {
 
 	Marshal() ([]byte, error)
 	Unmarshal(rawPacket []byte) error
+	String() string
 }
 
 // Unmarshal takes an entire udp datagram (which may consist of multiple RTCP packets) and

--- a/picture_loss_indication.go
+++ b/picture_loss_indication.go
@@ -14,8 +14,6 @@ type PictureLossIndication struct {
 	MediaSSRC uint32
 }
 
-var _ Packet = (*PictureLossIndication)(nil) // assert is a Packet
-
 const (
 	pliLength = 2
 )

--- a/picture_loss_indication_test.go
+++ b/picture_loss_indication_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+var _ Packet = (*PictureLossIndication)(nil) // assert is a Packet
+
 func TestPictureLossIndicationUnmarshal(t *testing.T) {
 	for _, test := range []struct {
 		Name      string

--- a/rapid_resynchronization_request.go
+++ b/rapid_resynchronization_request.go
@@ -14,8 +14,6 @@ type RapidResynchronizationRequest struct {
 	MediaSSRC uint32
 }
 
-var _ Packet = (*RapidResynchronizationRequest)(nil) // assert is a Packet
-
 const (
 	rrrLength       = 2
 	rrrHeaderLength = ssrcLength * 2

--- a/rapid_resynchronization_request_test.go
+++ b/rapid_resynchronization_request_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+var _ Packet = (*RapidResynchronizationRequest)(nil) // assert is a Packet
+
 func TestRapidResynchronizationRequestUnmarshal(t *testing.T) {
 	for _, test := range []struct {
 		Name      string

--- a/raw_packet.go
+++ b/raw_packet.go
@@ -6,8 +6,6 @@ import "fmt"
 // a packet with an unknown type is encountered.
 type RawPacket []byte
 
-var _ Packet = (*RawPacket)(nil) // assert is a Packet
-
 // Marshal encodes the packet in binary.
 func (r RawPacket) Marshal() ([]byte, error) {
 	return r, nil

--- a/raw_packet_test.go
+++ b/raw_packet_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+var _ Packet = (*RawPacket)(nil) // assert is a Packet
+
 func TestRawPacketRoundTrip(t *testing.T) {
 	for _, test := range []struct {
 		Name               string

--- a/receiver_estimated_maximum_bitrate.go
+++ b/receiver_estimated_maximum_bitrate.go
@@ -20,8 +20,6 @@ type ReceiverEstimatedMaximumBitrate struct {
 	SSRCs []uint32
 }
 
-var _ Packet = (*ReceiverEstimatedMaximumBitrate)(nil) // assert is a Packet
-
 // Marshal serializes the packet and returns a byte slice.
 func (p ReceiverEstimatedMaximumBitrate) Marshal() (buf []byte, err error) {
 	// Allocate a buffer of the exact output size.

--- a/receiver_estimated_maximum_bitrate_test.go
+++ b/receiver_estimated_maximum_bitrate_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var _ Packet = (*ReceiverEstimatedMaximumBitrate)(nil) // assert is a Packet
+
 func TestReceiverEstimatedMaximumBitrateMarshal(t *testing.T) {
 	assert := assert.New(t)
 

--- a/receiver_report.go
+++ b/receiver_report.go
@@ -19,8 +19,6 @@ type ReceiverReport struct {
 	ProfileExtensions []byte
 }
 
-var _ Packet = (*ReceiverReport)(nil) // assert is a Packet
-
 const (
 	ssrcLength     = 4
 	rrSSRCOffset   = headerLength

--- a/receiver_report_test.go
+++ b/receiver_report_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+var _ Packet = (*ReceiverReport)(nil) // assert is a Packet
+
 func TestReceiverReportUnmarshal(t *testing.T) {
 	for _, test := range []struct {
 		Name      string

--- a/sender_report.go
+++ b/sender_report.go
@@ -39,8 +39,6 @@ type SenderReport struct {
 	ProfileExtensions []byte
 }
 
-var _ Packet = (*SenderReport)(nil) // assert is a Packet
-
 const (
 	srHeaderLength      = 24
 	srSSRCOffset        = 0

--- a/sender_report_test.go
+++ b/sender_report_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+var _ Packet = (*SenderReport)(nil) // assert is a Packet
+
 func TestSenderReportUnmarshal(t *testing.T) {
 	for _, test := range []struct {
 		Name      string

--- a/slice_loss_indication.go
+++ b/slice_loss_indication.go
@@ -30,8 +30,6 @@ type SliceLossIndication struct {
 	SLI []SLIEntry
 }
 
-var _ Packet = (*SliceLossIndication)(nil) // assert is a Packet
-
 const (
 	sliLength = 2
 	sliOffset = 8

--- a/slice_loss_indication_test.go
+++ b/slice_loss_indication_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+var _ Packet = (*SliceLossIndication)(nil) // assert is a Packet
+
 func TestSliceLossIndicationUnmarshal(t *testing.T) {
 	for _, test := range []struct {
 		Name      string

--- a/source_description.go
+++ b/source_description.go
@@ -61,8 +61,6 @@ type SourceDescription struct {
 	Chunks []SourceDescriptionChunk
 }
 
-var _ Packet = (*SourceDescription)(nil) // assert is a Packet
-
 // Marshal encodes the SourceDescription in binary
 func (s SourceDescription) Marshal() ([]byte, error) {
 	/*

--- a/source_description_test.go
+++ b/source_description_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+var _ Packet = (*SourceDescription)(nil) // assert is a Packet
+
 func TestSourceDescriptionUnmarshal(t *testing.T) {
 	for _, test := range []struct {
 		Name      string

--- a/transport_layer_cc.go
+++ b/transport_layer_cc.go
@@ -75,8 +75,6 @@ func numOfBitsOfSymbolSize() map[uint16]uint16 {
 	}
 }
 
-var _ Packet = (*TransportLayerCC)(nil) // assert is a Packet
-
 var (
 	errPacketStatusChunkLength = errors.New("packet status chunk must be 2 bytes")
 	errDeltaExceedLimit        = errors.New("delta exceed limit")

--- a/transport_layer_cc_test.go
+++ b/transport_layer_cc_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+var _ Packet = (*TransportLayerCC)(nil) // assert is a Packet
+
 func TestTransportLayerCC_RunLengthChunkUnmarshal(t *testing.T) {
 	for _, test := range []struct {
 		Name      string

--- a/transport_layer_nack.go
+++ b/transport_layer_nack.go
@@ -33,8 +33,6 @@ type TransportLayerNack struct {
 	Nacks []NackPair
 }
 
-var _ Packet = (*TransportLayerNack)(nil) // assert is a Packet
-
 // NackPairsFromSequenceNumbers generates a slice of NackPair from a list of SequenceNumbers
 // This handles generating the proper values for PacketID/LostPackets
 func NackPairsFromSequenceNumbers(sequenceNumbers []uint16) (pairs []NackPair) {

--- a/transport_layer_nack_test.go
+++ b/transport_layer_nack_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+var _ Packet = (*TransportLayerNack)(nil) // assert is a Packet
+
 func TestTransportLayerNackUnmarshal(t *testing.T) {
 	for _, test := range []struct {
 		Name      string


### PR DESCRIPTION
#### Description
Nearly all RTCP packet types already include `String()` methods, which are quite valuable for diagnostic and logging purposes. This PR updates the base `Packet` interface to include `String()` so that it can be used by applications without having to perform a complex set of type assertions.