### PR TITLE
Add support for RTCP Extended Reports

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -3,6 +3,7 @@
 #
 # This file is auto generated, using git to list all individuals contributors.
 # see `.github/generate-authors.sh` for the scripting
+Adam Roach <adam@caffeine.tv>
 adwpc <adwpc@hotmail.com>
 aggresss <aggresss@163.com>
 Atsushi Watanabe <atsushi.w@ieee.org>

--- a/errors.go
+++ b/errors.go
@@ -28,4 +28,7 @@ var (
 	errSSRCNumAndLengthMismatch = errors.New("SSRC num and length do not match")
 	errInvalidSizeOrStartIndex  = errors.New("invalid size or startIndex")
 	errInvalidBitrate           = errors.New("invalid bitrate")
+	errWrongChunkType           = errors.New("rtcp: wrong chunk type")
+	errBadStructMemberType      = errors.New("rtcp: struct contains unexpected member type")
+	errBadReadParameter         = errors.New("rtcp: cannot read into non-pointer")
 )

--- a/extended_report.go
+++ b/extended_report.go
@@ -1,0 +1,643 @@
+package rtcp
+
+import (
+	"fmt"
+)
+
+// The ExtendedReport packet is an Implementation of RTCP Extended
+// Reports defined in RFC 3611. It is used to convey detailed
+// information about an RTP stream. Each packet contains one or
+// more report blocks, each of which conveys a different kind of
+// information.
+//
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |V=2|P|reserved |   PT=XR=207   |             length            |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                              SSRC                             |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// :                         report blocks                         :
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+type ExtendedReport struct {
+	SenderSSRC uint32 `fmt:"0x%X"`
+	Reports    []ReportBlock
+}
+
+// ReportBlock represents a single report within an ExtendedReport
+// packet
+type ReportBlock interface {
+	DestinationSSRC() []uint32
+	setupBlockHeader()
+	unpackBlockHeader()
+}
+
+// TypeSpecificField as described in RFC 3611 section 4.5. In typical
+// cases, users of ExtendedReports shouldn't need to access this,
+// and should instead use the corresponding fields in the actual
+// report blocks themselves.
+type TypeSpecificField uint8
+
+// XRHeader defines the common fields that must appear at the start
+// of each report block. In typical cases, users of ExtendedReports
+// shouldn't need to access this. For locally-constructed report
+// blocks, these values will not be accurate until the corresponding
+// packet is marshaled.
+type XRHeader struct {
+	BlockType    BlockTypeType
+	TypeSpecific TypeSpecificField `fmt:"0x%X"`
+	BlockLength  uint16
+}
+
+// BlockTypeType specifies the type of report in a report block
+type BlockTypeType uint8
+
+// Extended Report block types from RFC 3611.
+const (
+	LossRLEReportBlockType               = 1 // RFC 3611, section 4.1
+	DuplicateRLEReportBlockType          = 2 // RFC 3611, section 4.2
+	PacketReceiptTimesReportBlockType    = 3 // RFC 3611, section 4.3
+	ReceiverReferenceTimeReportBlockType = 4 // RFC 3611, section 4.4
+	DLRRReportBlockType                  = 5 // RFC 3611, section 4.5
+	StatisticsSummaryReportBlockType     = 6 // RFC 3611, section 4.6
+	VoIPMetricsReportBlockType           = 7 // RFC 3611, section 4.7
+)
+
+// String converts the Extended report block types into readable strings
+func (t BlockTypeType) String() string {
+	switch t {
+	case LossRLEReportBlockType:
+		return "LossRLEReportBlockType"
+	case DuplicateRLEReportBlockType:
+		return "DuplicateRLEReportBlockType"
+	case PacketReceiptTimesReportBlockType:
+		return "PacketReceiptTimesReportBlockType"
+	case ReceiverReferenceTimeReportBlockType:
+		return "ReceiverReferenceTimeReportBlockType"
+	case DLRRReportBlockType:
+		return "DLRRReportBlockType"
+	case StatisticsSummaryReportBlockType:
+		return "StatisticsSummaryReportBlockType"
+	case VoIPMetricsReportBlockType:
+		return "VoIPMetricsReportBlockType"
+	}
+	return fmt.Sprintf("invalid value %d", t)
+}
+
+// rleReportBlock defines the common structure used by both
+// Loss RLE report blocks (RFC 3611 §4.1) and Duplicate RLE
+// report blocks (RFC 3611 §4.2).
+//
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |  BT = 1 or 2  | rsvd. |   T   |         block length          |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                        SSRC of source                         |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |          begin_seq            |             end_seq           |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |          chunk 1              |             chunk 2           |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// :                              ...                              :
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |          chunk n-1            |             chunk n           |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+type rleReportBlock struct {
+	XRHeader
+	T        uint8  `encoding:"omit"`
+	SSRC     uint32 `fmt:"0x%X"`
+	BeginSeq uint16
+	EndSeq   uint16
+	Chunks   []Chunk
+}
+
+// Chunk as defined in RFC 3611, section 4.1. These represent information
+// about packet losses and packet duplication. They have three representations:
+//
+// Run Length Chunk:
+//
+//   0                   1
+//   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//  |C|R|        run length         |
+//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//
+// Bit Vector Chunk:
+//
+//   0                   1
+//   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//  |C|        bit vector           |
+//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//
+// Terminating Null Chunk:
+//
+//   0                   1
+//   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//  |0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0|
+//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+type Chunk uint16
+
+// LossRLEReportBlock is used to report information about packet
+// losses, as described in RFC 3611, section 4.1
+type LossRLEReportBlock rleReportBlock
+
+// DestinationSSRC returns an array of SSRC values that this report block refers to.
+func (b *LossRLEReportBlock) DestinationSSRC() []uint32 {
+	return []uint32{b.SSRC}
+}
+
+func (b *LossRLEReportBlock) setupBlockHeader() {
+	b.XRHeader.BlockType = LossRLEReportBlockType
+	b.XRHeader.TypeSpecific = TypeSpecificField(b.T & 0x0F)
+	b.XRHeader.BlockLength = uint16(wireSize(b)/4 - 1)
+}
+
+func (b *LossRLEReportBlock) unpackBlockHeader() {
+	b.T = uint8(b.XRHeader.TypeSpecific) & 0x0F
+}
+
+// DuplicateRLEReportBlock is used to report information about packet
+// duplication, as described in RFC 3611, section 4.1
+type DuplicateRLEReportBlock rleReportBlock
+
+// DestinationSSRC returns an array of SSRC values that this report block refers to.
+func (b *DuplicateRLEReportBlock) DestinationSSRC() []uint32 {
+	return []uint32{b.SSRC}
+}
+
+func (b *DuplicateRLEReportBlock) setupBlockHeader() {
+	b.XRHeader.BlockType = DuplicateRLEReportBlockType
+	b.XRHeader.TypeSpecific = TypeSpecificField(b.T & 0x0F)
+	b.XRHeader.BlockLength = uint16(wireSize(b)/4 - 1)
+}
+
+func (b *DuplicateRLEReportBlock) unpackBlockHeader() {
+	b.T = uint8(b.XRHeader.TypeSpecific) & 0x0F
+}
+
+// ChunkType enumerates the three kinds of chunks described in RFC 3611 section 4.1.
+type ChunkType uint8
+
+// These are the valid values that ChunkType can assume
+const (
+	RunLengthChunkType       = 0
+	BitVectorChunkType       = 1
+	TerminatingNullChunkType = 2
+)
+
+func (c Chunk) String() string {
+	switch c.Type() {
+	case RunLengthChunkType:
+		runType, _ := c.RunType()
+		return fmt.Sprintf("[RunLength type=%d, length=%d]", runType, c.Value())
+	case BitVectorChunkType:
+		return fmt.Sprintf("[BitVector 0b%015b]", c.Value())
+	case TerminatingNullChunkType:
+		return "[TerminatingNull]"
+	}
+	return fmt.Sprintf("[0x%X]", uint16(c))
+}
+
+// Type returns the ChunkType that this Chunk represents
+func (c Chunk) Type() ChunkType {
+	if c == 0 {
+		return TerminatingNullChunkType
+	}
+	return ChunkType(c >> 15)
+}
+
+// RunType returns the RunType that this Chunk represents. It is
+// only valid if ChunkType is RunLengthChunkType.
+func (c Chunk) RunType() (uint, error) {
+	if c.Type() != RunLengthChunkType {
+		return 0, errWrongChunkType
+	}
+	return uint((c >> 14) & 0x01), nil
+}
+
+// Value returns the value represented in this Chunk
+func (c Chunk) Value() uint {
+	switch c.Type() {
+	case RunLengthChunkType:
+		return uint(c & 0x3FFF)
+	case BitVectorChunkType:
+		return uint(c & 0x7FFF)
+	case TerminatingNullChunkType:
+		return 0
+	}
+	return uint(c)
+}
+
+// PacketReceiptTimesReportBlock represents a Packet Receipt Times
+// report block, as described in RFC 3611 section 4.3.
+//
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |     BT=3      | rsvd. |   T   |         block length          |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                        SSRC of source                         |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |          begin_seq            |             end_seq           |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |       Receipt time of packet begin_seq                        |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |       Receipt time of packet (begin_seq + 1) mod 65536        |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// :                              ...                              :
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |       Receipt time of packet (end_seq - 1) mod 65536          |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+type PacketReceiptTimesReportBlock struct {
+	XRHeader
+	T           uint8  `encoding:"omit"`
+	SSRC        uint32 `fmt:"0x%X"`
+	BeginSeq    uint16
+	EndSeq      uint16
+	ReceiptTime []uint32
+}
+
+// DestinationSSRC returns an array of SSRC values that this report block refers to.
+func (b *PacketReceiptTimesReportBlock) DestinationSSRC() []uint32 {
+	return []uint32{b.SSRC}
+}
+
+func (b *PacketReceiptTimesReportBlock) setupBlockHeader() {
+	b.XRHeader.BlockType = PacketReceiptTimesReportBlockType
+	b.XRHeader.TypeSpecific = TypeSpecificField(b.T & 0x0F)
+	b.XRHeader.BlockLength = uint16(wireSize(b)/4 - 1)
+}
+
+func (b *PacketReceiptTimesReportBlock) unpackBlockHeader() {
+	b.T = uint8(b.XRHeader.TypeSpecific) & 0x0F
+}
+
+// ReceiverReferenceTimeReportBlock encodes a Receiver Reference Time
+// report block as described in RFC 3611 section 4.4.
+//
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |     BT=4      |   reserved    |       block length = 2        |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |              NTP timestamp, most significant word             |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |             NTP timestamp, least significant word             |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+type ReceiverReferenceTimeReportBlock struct {
+	XRHeader
+	NTPTimestamp uint64
+}
+
+// DestinationSSRC returns an array of SSRC values that this report block refers to.
+func (b *ReceiverReferenceTimeReportBlock) DestinationSSRC() []uint32 {
+	return []uint32{}
+}
+
+func (b *ReceiverReferenceTimeReportBlock) setupBlockHeader() {
+	b.XRHeader.BlockType = ReceiverReferenceTimeReportBlockType
+	b.XRHeader.TypeSpecific = 0
+	b.XRHeader.BlockLength = uint16(wireSize(b)/4 - 1)
+}
+
+func (b *ReceiverReferenceTimeReportBlock) unpackBlockHeader() {
+}
+
+// DLRRReportBlock encodes a DLRR Report Block as described in
+// RFC 3611 section 4.5.
+//
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |     BT=5      |   reserved    |         block length          |
+// +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+// |                 SSRC_1 (SSRC of first receiver)               | sub-
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ block
+// |                         last RR (LRR)                         |   1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                   delay since last RR (DLRR)                  |
+// +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+// |                 SSRC_2 (SSRC of second receiver)              | sub-
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ block
+// :                               ...                             :   2
+// +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+type DLRRReportBlock struct {
+	XRHeader
+	Reports []DLRRReport
+}
+
+// DLRRReport encodes a single report inside a DLRRReportBlock.
+type DLRRReport struct {
+	SSRC   uint32 `fmt:"0x%X"`
+	LastRR uint32
+	DLRR   uint32
+}
+
+// DestinationSSRC returns an array of SSRC values that this report block refers to.
+func (b *DLRRReportBlock) DestinationSSRC() []uint32 {
+	ssrc := make([]uint32, len(b.Reports))
+	for i, r := range b.Reports {
+		ssrc[i] = r.SSRC
+	}
+	return ssrc
+}
+
+func (b *DLRRReportBlock) setupBlockHeader() {
+	b.XRHeader.BlockType = DLRRReportBlockType
+	b.XRHeader.TypeSpecific = 0
+	b.XRHeader.BlockLength = uint16(wireSize(b)/4 - 1)
+}
+
+func (b *DLRRReportBlock) unpackBlockHeader() {
+}
+
+// StatisticsSummaryReportBlock encodes a Statistics Summary Report
+// Block as described in RFC 3611, section 4.6.
+//
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |     BT=6      |L|D|J|ToH|rsvd.|       block length = 9        |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                        SSRC of source                         |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |          begin_seq            |             end_seq           |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                        lost_packets                           |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                        dup_packets                            |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                         min_jitter                            |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                         max_jitter                            |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                         mean_jitter                           |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                         dev_jitter                            |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// | min_ttl_or_hl | max_ttl_or_hl |mean_ttl_or_hl | dev_ttl_or_hl |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+type StatisticsSummaryReportBlock struct {
+	XRHeader
+	LossReports      bool              `encoding:"omit"`
+	DuplicateReports bool              `encoding:"omit"`
+	JitterReports    bool              `encoding:"omit"`
+	TTLorHopLimit    TTLorHopLimitType `encoding:"omit"`
+	SSRC             uint32            `fmt:"0x%X"`
+	BeginSeq         uint16
+	EndSeq           uint16
+	LostPackets      uint32
+	DupPackets       uint32
+	MinJitter        uint32
+	MaxJitter        uint32
+	MeanJitter       uint32
+	DevJitter        uint32
+	MinTTLOrHL       uint8
+	MaxTTLOrHL       uint8
+	MeanTTLOrHL      uint8
+	DevTTLOrHL       uint8
+}
+
+// TTLorHopLimitType encodes values for the ToH field in
+// a StatisticsSummaryReportBlock
+type TTLorHopLimitType uint8
+
+// Values for TTLorHopLimitType
+const (
+	ToHMissing = 0
+	ToHIPv4    = 1
+	ToHIPv6    = 2
+)
+
+func (t TTLorHopLimitType) String() string {
+	switch t {
+	case ToHMissing:
+		return "[ToH Missing]"
+	case ToHIPv4:
+		return "[ToH = IPv4]"
+	case ToHIPv6:
+		return "[ToH = IPv6]"
+	}
+	return "[ToH Flag is Invalid]"
+}
+
+// DestinationSSRC returns an array of SSRC values that this report block refers to.
+func (b *StatisticsSummaryReportBlock) DestinationSSRC() []uint32 {
+	return []uint32{b.SSRC}
+}
+
+func (b *StatisticsSummaryReportBlock) setupBlockHeader() {
+	b.XRHeader.BlockType = StatisticsSummaryReportBlockType
+	b.XRHeader.TypeSpecific = 0x00
+	if b.LossReports {
+		b.XRHeader.TypeSpecific |= 0x80
+	}
+	if b.DuplicateReports {
+		b.XRHeader.TypeSpecific |= 0x40
+	}
+	if b.JitterReports {
+		b.XRHeader.TypeSpecific |= 0x20
+	}
+	b.XRHeader.TypeSpecific |= TypeSpecificField((b.TTLorHopLimit & 0x03) << 3)
+	b.XRHeader.BlockLength = uint16(wireSize(b)/4 - 1)
+}
+
+func (b *StatisticsSummaryReportBlock) unpackBlockHeader() {
+	b.LossReports = b.XRHeader.TypeSpecific&0x80 != 0
+	b.DuplicateReports = b.XRHeader.TypeSpecific&0x40 != 0
+	b.JitterReports = b.XRHeader.TypeSpecific&0x20 != 0
+	b.TTLorHopLimit = TTLorHopLimitType((b.XRHeader.TypeSpecific & 0x18) >> 3)
+}
+
+// VoIPMetricsReportBlock encodes a VoIP Metrics Report Block as described
+// in RFC 3611, section 4.7.
+//
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |     BT=7      |   reserved    |       block length = 8        |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                        SSRC of source                         |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |   loss rate   | discard rate  | burst density |  gap density  |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |       burst duration          |         gap duration          |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |     round trip delay          |       end system delay        |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// | signal level  |  noise level  |     RERL      |     Gmin      |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |   R factor    | ext. R factor |    MOS-LQ     |    MOS-CQ     |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |   RX config   |   reserved    |          JB nominal           |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |          JB maximum           |          JB abs max           |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+type VoIPMetricsReportBlock struct {
+	XRHeader
+	SSRC           uint32 `fmt:"0x%X"`
+	LossRate       uint8
+	DiscardRate    uint8
+	BurstDensity   uint8
+	GapDensity     uint8
+	BurstDuration  uint16
+	GapDuration    uint16
+	RoundTripDelay uint16
+	EndSystemDelay uint16
+	SignalLevel    uint8
+	NoiseLevel     uint8
+	RERL           uint8
+	Gmin           uint8
+	RFactor        uint8
+	ExtRFactor     uint8
+	MOSLQ          uint8
+	MOSCQ          uint8
+	RXConfig       uint8
+	_              uint8
+	JBNominal      uint16
+	JBMaximum      uint16
+	JBAbsMax       uint16
+}
+
+// DestinationSSRC returns an array of SSRC values that this report block refers to.
+func (b *VoIPMetricsReportBlock) DestinationSSRC() []uint32 {
+	return []uint32{b.SSRC}
+}
+
+func (b *VoIPMetricsReportBlock) setupBlockHeader() {
+	b.XRHeader.BlockType = VoIPMetricsReportBlockType
+	b.XRHeader.TypeSpecific = 0
+	b.XRHeader.BlockLength = uint16(wireSize(b)/4 - 1)
+}
+
+func (b *VoIPMetricsReportBlock) unpackBlockHeader() {
+}
+
+// UnknownReportBlock is used to store bytes for any report block
+// that has an unknown Report Block Type.
+type UnknownReportBlock struct {
+	XRHeader
+	Bytes []byte
+}
+
+// DestinationSSRC returns an array of SSRC values that this report block refers to.
+func (b *UnknownReportBlock) DestinationSSRC() []uint32 {
+	return []uint32{}
+}
+
+func (b *UnknownReportBlock) setupBlockHeader() {
+	b.XRHeader.BlockLength = uint16(wireSize(b)/4 - 1)
+}
+
+func (b *UnknownReportBlock) unpackBlockHeader() {
+}
+
+// Marshal encodes the ExtendedReport in binary
+func (x ExtendedReport) Marshal() ([]byte, error) {
+	for _, p := range x.Reports {
+		p.setupBlockHeader()
+	}
+
+	length := wireSize(x)
+
+	// RTCP Header
+	header := Header{
+		Type:   TypeExtendedReport,
+		Length: uint16(length / 4),
+	}
+	headerBuffer, err := header.Marshal()
+	if err != nil {
+		return []byte{}, err
+	}
+	length += len(headerBuffer)
+
+	rawPacket := make([]byte, length)
+	buffer := packetBuffer{bytes: rawPacket}
+
+	err = buffer.write(headerBuffer)
+	if err != nil {
+		return []byte{}, err
+	}
+	err = buffer.write(x)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return rawPacket, nil
+}
+
+// Unmarshal decodes the ExtendedReport from binary
+func (x *ExtendedReport) Unmarshal(b []byte) error {
+	var header Header
+	if err := header.Unmarshal(b); err != nil {
+		return err
+	}
+	if header.Type != TypeExtendedReport {
+		return errWrongType
+	}
+
+	buffer := packetBuffer{bytes: b[headerLength:]}
+	err := buffer.read(&x.SenderSSRC)
+	if err != nil {
+		return err
+	}
+
+	for len(buffer.bytes) > 0 {
+		var block ReportBlock
+
+		headerBuffer := buffer
+		xrHeader := XRHeader{}
+		err = headerBuffer.read(&xrHeader)
+		if err != nil {
+			return err
+		}
+
+		switch xrHeader.BlockType {
+		case LossRLEReportBlockType:
+			block = new(LossRLEReportBlock)
+		case DuplicateRLEReportBlockType:
+			block = new(DuplicateRLEReportBlock)
+		case PacketReceiptTimesReportBlockType:
+			block = new(PacketReceiptTimesReportBlock)
+		case ReceiverReferenceTimeReportBlockType:
+			block = new(ReceiverReferenceTimeReportBlock)
+		case DLRRReportBlockType:
+			block = new(DLRRReportBlock)
+		case StatisticsSummaryReportBlockType:
+			block = new(StatisticsSummaryReportBlock)
+		case VoIPMetricsReportBlockType:
+			block = new(VoIPMetricsReportBlock)
+		default:
+			block = new(UnknownReportBlock)
+		}
+
+		// We need to limit the amount of data available to
+		// this block to the actual length of the block
+		blockLength := (int(xrHeader.BlockLength) + 1) * 4
+		blockBuffer := buffer.split(blockLength)
+		err = blockBuffer.read(block)
+		if err != nil {
+			return err
+		}
+		block.unpackBlockHeader()
+		x.Reports = append(x.Reports, block)
+	}
+
+	return nil
+}
+
+// DestinationSSRC returns an array of SSRC values that this packet refers to.
+func (x *ExtendedReport) DestinationSSRC() []uint32 {
+	ssrc := make([]uint32, 0)
+	for _, p := range x.Reports {
+		ssrc = append(ssrc, p.DestinationSSRC()...)
+	}
+	return ssrc
+}
+
+func (x *ExtendedReport) String() string {
+	return stringify(x)
+}

--- a/extended_report_test.go
+++ b/extended_report_test.go
@@ -1,0 +1,261 @@
+package rtcp
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Assert that ExtendedReport is a Packet
+var _ Packet = (*ExtendedReport)(nil)
+
+// Assert that all the extended report blocks implement the interface
+var (
+	_ ReportBlock = (*LossRLEReportBlock)(nil)
+	_ ReportBlock = (*DuplicateRLEReportBlock)(nil)
+	_ ReportBlock = (*PacketReceiptTimesReportBlock)(nil)
+	_ ReportBlock = (*ReceiverReferenceTimeReportBlock)(nil)
+	_ ReportBlock = (*DLRRReportBlock)(nil)
+	_ ReportBlock = (*StatisticsSummaryReportBlock)(nil)
+	_ ReportBlock = (*VoIPMetricsReportBlock)(nil)
+	_ ReportBlock = (*UnknownReportBlock)(nil)
+)
+
+func testPacket() Packet {
+	return &ExtendedReport{
+		SenderSSRC: 0x01020304,
+		Reports: []ReportBlock{
+			&LossRLEReportBlock{
+				XRHeader: XRHeader{
+					BlockType: LossRLEReportBlockType,
+				},
+				T:        12,
+				SSRC:     0x12345689,
+				BeginSeq: 5,
+				EndSeq:   12,
+				Chunks: []Chunk{
+					Chunk(0x4006),
+					Chunk(0x0006),
+					Chunk(0x8765),
+					Chunk(0x0000),
+				},
+			},
+			&DuplicateRLEReportBlock{
+				XRHeader: XRHeader{
+					BlockType: DuplicateRLEReportBlockType,
+				},
+				T:        6,
+				SSRC:     0x12345689,
+				BeginSeq: 5,
+				EndSeq:   12,
+				Chunks: []Chunk{
+					Chunk(0x4123),
+					Chunk(0x3FFF),
+					Chunk(0xFFFF),
+					Chunk(0x0000),
+				},
+			},
+			&PacketReceiptTimesReportBlock{
+				XRHeader: XRHeader{
+					BlockType: PacketReceiptTimesReportBlockType,
+				},
+				T:        3,
+				SSRC:     0x98765432,
+				BeginSeq: 15432,
+				EndSeq:   15577,
+				ReceiptTime: []uint32{
+					0x11111111,
+					0x22222222,
+					0x33333333,
+					0x44444444,
+					0x55555555,
+				},
+			},
+			&ReceiverReferenceTimeReportBlock{
+				XRHeader: XRHeader{
+					BlockType: ReceiverReferenceTimeReportBlockType,
+				},
+				NTPTimestamp: 0x0102030405060708,
+			},
+			&DLRRReportBlock{
+				XRHeader: XRHeader{
+					BlockType: DLRRReportBlockType,
+				},
+				Reports: []DLRRReport{
+					{
+						SSRC:   0x88888888,
+						LastRR: 0x12345678,
+						DLRR:   0x99999999,
+					},
+					{
+						SSRC:   0x09090909,
+						LastRR: 0x12345678,
+						DLRR:   0x99999999,
+					},
+					{
+						SSRC:   0x11223344,
+						LastRR: 0x12345678,
+						DLRR:   0x99999999,
+					},
+				},
+			},
+			&StatisticsSummaryReportBlock{
+				XRHeader{
+					BlockType: StatisticsSummaryReportBlockType,
+				},
+				true, true, true, ToHIPv4,
+				0xFEDCBA98,
+				0x1234, 0x5678,
+				0x11111111,
+				0x22222222,
+				0x33333333,
+				0x44444444,
+				0x55555555,
+				0x66666666,
+				0x01, 0x02, 0x03, 0x04,
+			},
+			&VoIPMetricsReportBlock{
+				XRHeader{
+					BlockType: VoIPMetricsReportBlockType,
+				},
+				0x89ABCDEF,
+				0x05, 0x06, 0x07, 0x08,
+				0x1111, 0x2222, 0x3333, 0x4444,
+				0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+				0x00,
+				0x1122, 0x3344, 0x5566,
+			},
+		},
+	}
+}
+
+func encodedPacket() []byte {
+	return []byte{
+		// RTP Header
+		0x80, 0xCF, 0x00, 0x33, // byte 0 - 3
+		// Sender SSRC
+		0x01, 0x02, 0x03, 0x04,
+		// Loss RLE Report Block
+		0x01, 0x0C, 0x00, 0x04, // byte 8 - 11
+		// Source SSRC
+		0x12, 0x34, 0x56, 0x89,
+		// Begin & End Seq
+		0x00, 0x05, 0x00, 0x0C, // byte 16 - 19
+		// Chunks
+		0x40, 0x06, 0x00, 0x06,
+		0x87, 0x65, 0x00, 0x00, // byte 24 - 27
+		// Duplicate RLE Report Block
+		0x02, 0x06, 0x00, 0x04,
+		// Source SSRC
+		0x12, 0x34, 0x56, 0x89, // byte 32 - 35
+		// Begin & End Seq
+		0x00, 0x05, 0x00, 0x0C,
+		// Chunks
+		0x41, 0x23, 0x3F, 0xFF, // byte 40 - 43
+		0xFF, 0xFF, 0x00, 0x00,
+		// Packet Receipt Times Report Block
+		0x03, 0x03, 0x00, 0x07, // byte 48 - 51
+		// Source SSRC
+		0x98, 0x76, 0x54, 0x32,
+		// Begin & End Seq
+		0x3C, 0x48, 0x3C, 0xD9, // byte 56 - 59
+		// Receipt times
+		0x11, 0x11, 0x11, 0x11,
+		0x22, 0x22, 0x22, 0x22, // byte 64 - 67
+		0x33, 0x33, 0x33, 0x33,
+		0x44, 0x44, 0x44, 0x44, // byte 72 - 75
+		0x55, 0x55, 0x55, 0x55,
+		// Receiver Reference Time Report
+		0x04, 0x00, 0x00, 0x02, // byte 80 - 83
+		// Timestamp
+		0x01, 0x02, 0x03, 0x04,
+		0x05, 0x06, 0x07, 0x08, // byte 88 - 91
+		// DLRR Report
+		0x05, 0x00, 0x00, 0x09,
+		// SSRC 1
+		0x88, 0x88, 0x88, 0x88, // byte 96 - 99
+		// LastRR 1
+		0x12, 0x34, 0x56, 0x78,
+		// DLRR 1
+		0x99, 0x99, 0x99, 0x99, // byte 104 - 107
+		// SSRC 2
+		0x09, 0x09, 0x09, 0x09,
+		// LastRR 2
+		0x12, 0x34, 0x56, 0x78, // byte 112 - 115
+		// DLRR 2
+		0x99, 0x99, 0x99, 0x99,
+		// SSRC 3
+		0x11, 0x22, 0x33, 0x44, // byte 120 - 123
+		// LastRR 3
+		0x12, 0x34, 0x56, 0x78,
+		// DLRR 3
+		0x99, 0x99, 0x99, 0x99, // byte 128 - 131
+		// Statistics Summary Report
+		0x06, 0xE8, 0x00, 0x09,
+		// SSRC
+		0xFE, 0xDC, 0xBA, 0x98, // byte 136 - 139
+		// Various statistics
+		0x12, 0x34, 0x56, 0x78,
+		0x11, 0x11, 0x11, 0x11, // byte 144 - 147
+		0x22, 0x22, 0x22, 0x22,
+		0x33, 0x33, 0x33, 0x33, // byte 152 - 155
+		0x44, 0x44, 0x44, 0x44,
+		0x55, 0x55, 0x55, 0x55, // byte 160 - 163
+		0x66, 0x66, 0x66, 0x66,
+		0x01, 0x02, 0x03, 0x04, // byte 168 - 171
+		// VoIP Metrics Report
+		0x07, 0x00, 0x00, 0x08,
+		// SSRC
+		0x89, 0xAB, 0xCD, 0xEF, // byte 176 - 179
+		// Various statistics
+		0x05, 0x06, 0x07, 0x08,
+		0x11, 0x11, 0x22, 0x22, // byte 184 - 187
+		0x33, 0x33, 0x44, 0x44,
+		0x11, 0x22, 0x33, 0x44, // byte 192 - 195
+		0x55, 0x66, 0x77, 0x88,
+		0x99, 0x00, 0x11, 0x22, // byte 200 - 203
+		0x33, 0x44, 0x55, 0x66, // byte 204 - 207
+	}
+}
+
+func TestEncode(t *testing.T) {
+	expected := encodedPacket()
+	packet := testPacket()
+	rawPacket, err := packet.Marshal()
+	if err != nil {
+		t.Fatalf("Error marshaling packet: %v", err)
+	}
+	if len(rawPacket) != len(expected) {
+		t.Fatalf("Encoded message is %d bytes; expected is %d", len(rawPacket), len(expected))
+	}
+
+	for i := 0; i < len(rawPacket); i++ {
+		if rawPacket[i] != expected[i] {
+			t.Errorf("Byte %d of encoded packet does not match: expected 0x%02X, got 0x%02X", i, expected[i], rawPacket[i])
+		}
+	}
+}
+
+func TestDecode(t *testing.T) {
+	encoded := encodedPacket()
+	expected := testPacket()
+
+	// We need to make sure the header has been set up correctly
+	// before we test for equality
+	for _, p := range expected.(*ExtendedReport).Reports {
+		p.setupBlockHeader()
+	}
+
+	p := new(ExtendedReport)
+	err := p.Unmarshal(encoded)
+	if err != nil {
+		t.Fatalf("Error unmarshaling packet: %v", err)
+	}
+
+	if !reflect.DeepEqual(p, expected) {
+		t.Errorf("(deep equal) Decoded packet does not match expected packet")
+	}
+
+	if p.String() != expected.String() {
+		t.Errorf("(string compare) Decoded packet does not match expected packet")
+	}
+}

--- a/header.go
+++ b/header.go
@@ -16,6 +16,7 @@ const (
 	TypeApplicationDefined        PacketType = 204 // RFC 3550, 6.7 (unimplemented)
 	TypeTransportSpecificFeedback PacketType = 205 // RFC 4585, 6051
 	TypePayloadSpecificFeedback   PacketType = 206 // RFC 4585, 6.3
+	TypeExtendedReport            PacketType = 207 // RFC 3611
 
 )
 
@@ -28,7 +29,7 @@ const (
 	FormatRRR  uint8 = 5
 	FormatREMB uint8 = 15
 
-	//https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#page-5
+	// https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#page-5
 	FormatTCC uint8 = 15
 )
 
@@ -48,6 +49,8 @@ func (p PacketType) String() string {
 		return "TSFB"
 	case TypePayloadSpecificFeedback:
 		return "PSFB"
+	case TypeExtendedReport:
+		return "XR"
 	default:
 		return string(p)
 	}

--- a/packet.go
+++ b/packet.go
@@ -106,6 +106,9 @@ func unmarshal(rawData []byte) (packet Packet, bytesprocessed int, err error) {
 			packet = new(RawPacket)
 		}
 
+	case TypeExtendedReport:
+		packet = new(ExtendedReport)
+
 	default:
 		packet = new(RawPacket)
 	}

--- a/packet_buffer.go
+++ b/packet_buffer.go
@@ -1,0 +1,256 @@
+package rtcp
+
+import (
+	"encoding/binary"
+	"reflect"
+	"unsafe"
+)
+
+// These functions implement an introspective structure
+// serializer/deserializer, designed to allow RTCP packet
+// Structs to be self-describing. They currently work with
+// fields of type uint8, uint16, uint32, and uint64 (and
+// types derived from them).
+//
+// - Unexported fields will take up space in the encoded
+//   array, but wil be set to zero when written, and ignore
+//   when read.
+//
+// - Fields that are marked with the tag `encoding:"omit"`
+//   will be ignored when reading and writing data.
+//
+// For example:
+//
+//   type Example struct {
+//     A uint32
+//     B bool   `encoding:"omit"`
+//     _ uint64
+//     C uint16
+//   }
+//
+// "A" will be encoded as four bytes, in network order. "B"
+// will not be encoded at all. The anonymous uint64 will
+// encode as 8 bytes of value "0", followed by two bytes
+// encoding "C" in network order.
+
+type packetBuffer struct {
+	bytes []byte
+}
+
+const omit = "omit"
+
+// Writes the structure passed to into the buffer that
+// PacketBuffer is initialized with. This function will
+// modify the PacketBuffer.bytes slice to exclude those
+// bytes that have been written into.
+//
+func (b *packetBuffer) write(v interface{}) error { //nolint:gocognit
+	value := reflect.ValueOf(v)
+
+	// Indirect is safe to call on non-pointers, and
+	// will simply return the same value in such cases
+	value = reflect.Indirect(value)
+
+	switch value.Kind() {
+	case reflect.Uint8:
+		if len(b.bytes) < 1 {
+			return errWrongMarshalSize
+		}
+		if value.CanInterface() {
+			b.bytes[0] = byte(value.Uint())
+		}
+		b.bytes = b.bytes[1:]
+	case reflect.Uint16:
+		if len(b.bytes) < 2 {
+			return errWrongMarshalSize
+		}
+		if value.CanInterface() {
+			binary.BigEndian.PutUint16(b.bytes, uint16(value.Uint()))
+		}
+		b.bytes = b.bytes[2:]
+	case reflect.Uint32:
+		if len(b.bytes) < 4 {
+			return errWrongMarshalSize
+		}
+		if value.CanInterface() {
+			binary.BigEndian.PutUint32(b.bytes, uint32(value.Uint()))
+		}
+		b.bytes = b.bytes[4:]
+	case reflect.Uint64:
+		if len(b.bytes) < 8 {
+			return errWrongMarshalSize
+		}
+		if value.CanInterface() {
+			binary.BigEndian.PutUint64(b.bytes, value.Uint())
+		}
+		b.bytes = b.bytes[8:]
+	case reflect.Slice:
+		for i := 0; i < value.Len(); i++ {
+			if value.Index(i).CanInterface() {
+				if err := b.write(value.Index(i).Interface()); err != nil {
+					return err
+				}
+			} else {
+				b.bytes = b.bytes[value.Index(i).Type().Size():]
+			}
+		}
+	case reflect.Struct:
+		for i := 0; i < value.NumField(); i++ {
+			encoding := value.Type().Field(i).Tag.Get("encoding")
+			if encoding == omit {
+				continue
+			}
+			if value.Field(i).CanInterface() {
+				if err := b.write(value.Field(i).Interface()); err != nil {
+					return err
+				}
+			} else {
+				advance := int(value.Field(i).Type().Size())
+				if len(b.bytes) < advance {
+					return errWrongMarshalSize
+				}
+				b.bytes = b.bytes[advance:]
+			}
+		}
+	default:
+		return errBadStructMemberType
+	}
+	return nil
+}
+
+// Reads bytes from the buffer as necessary to populate
+// the structure passed as a parameter. This function will
+// modify the PacketBuffer.bytes slice to exclude those
+// bytes that have already been read.
+func (b *packetBuffer) read(v interface{}) error { //nolint:gocognit
+	ptr := reflect.ValueOf(v)
+	if ptr.Kind() != reflect.Ptr {
+		return errBadReadParameter
+	}
+	value := reflect.Indirect(ptr)
+
+	// If this is an interface, we need to make it concrete before using it
+	if value.Kind() == reflect.Interface {
+		value = reflect.ValueOf(value.Interface())
+	}
+	value = reflect.Indirect(value)
+
+	switch value.Kind() {
+	case reflect.Uint8:
+		if len(b.bytes) < 1 {
+			return errWrongMarshalSize
+		}
+		value.SetUint(uint64(b.bytes[0]))
+		b.bytes = b.bytes[1:]
+
+	case reflect.Uint16:
+		if len(b.bytes) < 2 {
+			return errWrongMarshalSize
+		}
+		value.SetUint(uint64(binary.BigEndian.Uint16(b.bytes)))
+		b.bytes = b.bytes[2:]
+
+	case reflect.Uint32:
+		if len(b.bytes) < 4 {
+			return errWrongMarshalSize
+		}
+		value.SetUint(uint64(binary.BigEndian.Uint32(b.bytes)))
+		b.bytes = b.bytes[4:]
+
+	case reflect.Uint64:
+		if len(b.bytes) < 8 {
+			return errWrongMarshalSize
+		}
+		value.SetUint(binary.BigEndian.Uint64(b.bytes))
+		b.bytes = b.bytes[8:]
+
+	case reflect.Slice:
+		// If we encounter a slice, we consume the rest of the data
+		// in the buffer and load it into the slice.
+		for len(b.bytes) > 0 {
+			newElementPtr := reflect.New(value.Type().Elem())
+			if err := b.read(newElementPtr.Interface()); err != nil {
+				return err
+			}
+			if value.CanSet() {
+				value.Set(reflect.Append(value, reflect.Indirect(newElementPtr)))
+			}
+		}
+
+	case reflect.Struct:
+		for i := 0; i < value.NumField(); i++ {
+			encoding := value.Type().Field(i).Tag.Get("encoding")
+			if encoding == omit {
+				continue
+			}
+			if value.Field(i).CanInterface() {
+				field := value.Field(i)
+				newFieldPtr := reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())) //nolint:gosec // This is the only way to get a typed pointer to a structure's field
+				if err := b.read(newFieldPtr.Interface()); err != nil {
+					return err
+				}
+			} else {
+				advance := int(value.Field(i).Type().Size())
+				if len(b.bytes) < advance {
+					return errWrongMarshalSize
+				}
+				b.bytes = b.bytes[advance:]
+			}
+		}
+
+	default:
+		return errBadStructMemberType
+	}
+	return nil
+}
+
+// Consumes `size` bytes and returns them as an
+// independent PacketBuffer
+func (b *packetBuffer) split(size int) packetBuffer {
+	if size > len(b.bytes) {
+		size = len(b.bytes)
+	}
+	newBuffer := packetBuffer{bytes: b.bytes[:size]}
+	b.bytes = b.bytes[size:]
+	return newBuffer
+}
+
+// Returns the size that a structure will encode into.
+// This fuction doesn't check that Write() will succeed,
+// and may return unexpectedly large results for those
+// structures that Write() will fail on
+func wireSize(v interface{}) int {
+	value := reflect.ValueOf(v)
+	// Indirect is safe to call on non-pointers, and
+	// will simply return the same value in such cases
+	value = reflect.Indirect(value)
+	size := int(0)
+
+	switch value.Kind() {
+	case reflect.Slice:
+		for i := 0; i < value.Len(); i++ {
+			if value.Index(i).CanInterface() {
+				size += wireSize(value.Index(i).Interface())
+			} else {
+				size += int(value.Index(i).Type().Size())
+			}
+		}
+
+	case reflect.Struct:
+		for i := 0; i < value.NumField(); i++ {
+			encoding := value.Type().Field(i).Tag.Get("encoding")
+			if encoding == omit {
+				continue
+			}
+			if value.Field(i).CanInterface() {
+				size += wireSize(value.Field(i).Interface())
+			} else {
+				size += int(value.Field(i).Type().Size())
+			}
+		}
+
+	default:
+		size = int(value.Type().Size())
+	}
+	return size
+}

--- a/packet_buffer_test.go
+++ b/packet_buffer_test.go
@@ -1,0 +1,208 @@
+package rtcp
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestWrite(t *testing.T) {
+	type Subtree struct {
+		SubA uint32
+		SubB []uint8
+	}
+
+	s := struct {
+		A uint8
+		Z uint32 `encoding:"omit"`
+		B uint16
+		C uint32
+		D uint64
+		_ uint8
+		E []uint16
+		F Subtree
+		G []Subtree
+	}{
+		0xf8,
+		0x01234567,
+		0x1234,
+		0x56789ABC,
+		0x0102030405060708,
+		0x12,
+		[]uint16{0x0E, 0x02FF},
+		Subtree{0x11223344, []uint8{9, 8, 7, 6, 5, 4, 3, 2, 1}},
+		[]Subtree{{0x01, []uint8{1, 2, 3, 4}}, {0x02, []uint8{5, 6, 7, 8}}},
+	}
+	expected := []byte{
+		0xf8,
+		0x12, 0x34,
+		0x56, 0x78, 0x9A, 0xBC,
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x00,
+		0x00, 0x0E, 0x02, 0xFF,
+		0x11, 0x22, 0x33, 0x44, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+		0x00, 0x00, 0x00, 0x01, 1, 2, 3, 4, 0x00, 0x00, 0x00, 0x02, 5, 6, 7, 8,
+	}
+
+	size := wireSize(s)
+	if size != len(expected) {
+		t.Fatalf("wireSize() returned unexpected value. Expected %v, got %v", len(expected), size)
+	}
+
+	raw := make([]byte, len(expected))
+	buffer := packetBuffer{bytes: raw}
+	err := buffer.write(s)
+	if err != nil {
+		t.Fatalf("Serialization failed. Err = %v", err)
+	}
+	if !bytes.Equal(raw, expected) {
+		t.Fatalf("Serialization failed. Wanted %v, got %v", expected, raw)
+	}
+
+	// Check for overflow
+	raw = make([]byte, len(expected)-1)
+	buffer = packetBuffer{bytes: raw}
+	err = buffer.write(s)
+	if !errors.Is(err, errWrongMarshalSize) {
+		t.Fatalf("Serialization failed. Err = %v", err)
+	}
+}
+
+func TestReadUint8(t *testing.T) {
+	const expected = 0x01
+	raw := []byte{expected}
+	output := uint8(0)
+	buffer := packetBuffer{bytes: raw}
+	err := buffer.read(&output)
+	if err != nil {
+		t.Fatalf("Value parsing failed. Err = %v", err)
+	}
+	if output != expected {
+		t.Fatalf("Reading uint8 failed. Wanted %X, got %X", expected, output)
+	}
+}
+
+func TestReadUint16(t *testing.T) {
+	const expected = 0x0102
+	raw := []byte{0x01, 0x02}
+	output := uint16(0)
+	buffer := packetBuffer{bytes: raw}
+	err := buffer.read(&output)
+	if err != nil {
+		t.Fatalf("Value parsing failed. Err = %v", err)
+	}
+	if output != expected {
+		t.Fatalf("Reading uint16 failed. Wanted %X, got %X", expected, output)
+	}
+}
+
+func TestReadUint32(t *testing.T) {
+	const expected = 0x01020304
+	raw := []byte{0x01, 0x02, 0x03, 0x04}
+	output := uint32(0)
+	buffer := packetBuffer{bytes: raw}
+	err := buffer.read(&output)
+	if err != nil {
+		t.Fatalf("Value parsing failed. Err = %v", err)
+	}
+	if output != expected {
+		t.Fatalf("Reading uint32 failed. Wanted %X, got %X", expected, output)
+	}
+}
+
+func TestReadUint64(t *testing.T) {
+	expected := uint64(0x0102030405060708)
+	raw := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	output := uint64(0)
+	buffer := packetBuffer{bytes: raw}
+	err := buffer.read(&output)
+	if err != nil {
+		t.Fatalf("Value parsing failed. Err = %v", err)
+	}
+	if output != expected {
+		t.Fatalf("Reading uint64 failed. Wanted %X, got %X", expected, output)
+	}
+}
+
+func TestReadStruct(t *testing.T) {
+	type S struct {
+		A uint8
+		B uint16
+		C uint32
+		D uint64
+	}
+	expected := S{0x01, 0x0203, 0x04050607, 0x08090A0B0C0D0E0F}
+	raw := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
+	var output S
+	buffer := packetBuffer{bytes: raw}
+	err := buffer.read(&output)
+	if err != nil {
+		t.Fatalf("Struct parsing failed. Err = %v", err)
+	}
+	if output != expected {
+		t.Fatalf("Reading struct failed. Wanted %v, got %v", expected, output)
+	}
+}
+
+func TestReadSlice(t *testing.T) {
+	expected := []uint16{0x0102, 0x0304, 0x0506, 0x0708}
+	raw := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	var output []uint16
+	buffer := packetBuffer{bytes: raw}
+	err := buffer.read(&output)
+	if err != nil {
+		t.Fatalf("Slice parsing failed. Err = %v", err)
+	}
+	if fmt.Sprintf("%x", output) != fmt.Sprintf("%x", expected) {
+		t.Fatalf("Reading struct failed. Wanted %v, got %v", expected, output)
+	}
+}
+
+func TestReadComplex(t *testing.T) {
+	raw := []byte{
+		0xf8,
+		0x12, 0x34,
+		0x56, 0x78, 0x9A, 0xBC,
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x12,
+		0x11, 0x22, 0x33, 0x44, 9,
+		0x00, 0x00, 0x00, 0x01, 1, 0x00, 0x00, 0x00, 0x02, 5,
+	}
+
+	type Subtree struct {
+		SubA uint32
+		SubB uint8
+	}
+
+	type Tree struct {
+		A uint8
+		B uint16
+		C uint32
+		D uint64
+		_ uint8
+		F Subtree
+		G []Subtree
+	}
+
+	expected := Tree{
+		0xf8,
+		0x1234,
+		0x56789ABC,
+		0x0102030405060708,
+		0x00,
+		Subtree{0x11223344, 9},
+		[]Subtree{{0x01, 1}, {0x02, 5}},
+	}
+
+	var output Tree
+
+	buffer := packetBuffer{bytes: raw}
+	err := buffer.read(&output)
+	if err != nil {
+		t.Fatalf("Complex parsing failed. Err = %v", err)
+	}
+	if fmt.Sprintf("%x", output) != fmt.Sprintf("%x", expected) {
+		t.Fatalf("Reading struct failed. Wanted %v, got %v", expected, output)
+	}
+}

--- a/packet_stringifier.go
+++ b/packet_stringifier.go
@@ -1,0 +1,103 @@
+package rtcp
+
+import (
+	"fmt"
+	"reflect"
+)
+
+/*
+	Converts an RTCP Packet into a human-readable format. The Packets
+	themselves can control the presentation as follows:
+
+	- Fields of a type that have a String() method will be formatted
+	  with that String method (which should not emit '\n' characters)
+
+	- Otherwise, fields with a tag containing a "fmt" string will use that
+	  format when serializing the value. For example, to format an SSRC
+	  value as base 16 insted of base 10:
+
+	  type ExamplePacket struct {
+	  	LocalSSRC   uint32   `fmt:"0x%X"`
+	  	RemotsSSRCs []uint32 `fmt:"%X"`
+	  }
+
+	- If no fmt string is present, "%+v" is used by default
+
+	The intention of this stringify() function is to simplify creation
+	of String() methods on new packet types, as it provides a simple
+	baseline implementation that works well in the majority of cases.
+*/
+func stringify(p Packet) string {
+	value := reflect.Indirect(reflect.ValueOf(p))
+	return formatField(value.Type().String(), "", p, "")
+}
+
+func formatField(name string, format string, f interface{}, indent string) string { //nolint:gocognit
+	out := indent
+	value := reflect.ValueOf(f)
+
+	if !value.IsValid() {
+		return fmt.Sprintf("%s%s: <nil>\n", out, name)
+	}
+
+	isPacket := reflect.TypeOf(f).Implements(reflect.TypeOf((*Packet)(nil)).Elem())
+
+	// Resolve pointers to their underlying values
+	if value.Type().Kind() == reflect.Ptr && !value.IsNil() {
+		underlying := reflect.Indirect(value)
+		if underlying.IsValid() {
+			value = underlying
+		}
+	}
+
+	// If the field type has a custom String method, use that
+	// (unless we're a packet, since we want to avoid recursing
+	// back into this function if the Packet's String() method
+	// uses it)
+	if stringMethod := value.MethodByName("String"); !isPacket && stringMethod.IsValid() {
+		out += fmt.Sprintf("%s: %s\n", name, stringMethod.Call([]reflect.Value{}))
+		return out
+	}
+
+	switch value.Kind() {
+	case reflect.Struct:
+		out += fmt.Sprintf("%s:\n", name)
+		for i := 0; i < value.NumField(); i++ {
+			if value.Field(i).CanInterface() {
+				format = value.Type().Field(i).Tag.Get("fmt")
+				if format == "" {
+					format = "%+v"
+				}
+				out += formatField(value.Type().Field(i).Name, format, value.Field(i).Interface(), indent+"\t")
+			}
+		}
+	case reflect.Slice:
+		childKind := value.Type().Elem().Kind()
+		_, hasStringMethod := value.Type().Elem().MethodByName("String")
+		if hasStringMethod || childKind == reflect.Struct || childKind == reflect.Ptr || childKind == reflect.Interface || childKind == reflect.Slice {
+			out += fmt.Sprintf("%s:\n", name)
+			for i := 0; i < value.Len(); i++ {
+				childName := fmt.Sprint(i)
+				// Since interfaces can hold different types of things, we add the
+				// most specific type name to the name to make it clear what the
+				// subsequent fields represent.
+				if value.Index(i).Kind() == reflect.Interface {
+					childName += fmt.Sprintf(" (%s)", reflect.Indirect(reflect.ValueOf(value.Index(i).Interface())).Type())
+				}
+				if value.Index(i).CanInterface() {
+					out += formatField(childName, format, value.Index(i).Interface(), indent+"\t")
+				}
+			}
+			return out
+		}
+
+		// If we didn't take care of stringing the value already, we fall through to the
+		// generic case. This will print slices of basic types on a single line.
+		fallthrough
+	default:
+		if value.CanInterface() {
+			out += fmt.Sprintf("%s: "+format+"\n", name, value.Interface())
+		}
+	}
+	return out
+}

--- a/packet_stringifier_test.go
+++ b/packet_stringifier_test.go
@@ -1,0 +1,514 @@
+package rtcp
+
+import (
+	"testing"
+)
+
+func TestPrint(t *testing.T) {
+	type Tests struct {
+		packet   Packet
+		expected string
+	}
+
+	tests := []Tests{
+		{
+			&ExtendedReport{
+				SenderSSRC: 0x01020304,
+				Reports: []ReportBlock{
+					&LossRLEReportBlock{
+						XRHeader: XRHeader{
+							BlockType: LossRLEReportBlockType,
+						},
+						SSRC:     0x12345689,
+						BeginSeq: 5,
+						EndSeq:   12,
+						Chunks: []Chunk{
+							Chunk(0x4006),
+							Chunk(0x0006),
+							Chunk(0x8765),
+							Chunk(0x0000),
+						},
+					},
+					&DuplicateRLEReportBlock{
+						XRHeader: XRHeader{
+							BlockType: DuplicateRLEReportBlockType,
+						},
+						SSRC:     0x12345689,
+						BeginSeq: 5,
+						EndSeq:   12,
+						Chunks: []Chunk{
+							Chunk(0x4123),
+							Chunk(0x3FFF),
+							Chunk(0xFFFF),
+							Chunk(0x0000),
+						},
+					},
+					&PacketReceiptTimesReportBlock{
+						XRHeader: XRHeader{
+							BlockType: PacketReceiptTimesReportBlockType,
+						},
+						SSRC:     0x98765432,
+						BeginSeq: 15432,
+						EndSeq:   15577,
+						ReceiptTime: []uint32{
+							0x11111111,
+							0x22222222,
+							0x33333333,
+							0x44444444,
+							0x55555555,
+						},
+					},
+					&ReceiverReferenceTimeReportBlock{
+						XRHeader: XRHeader{
+							BlockType: ReceiverReferenceTimeReportBlockType,
+						},
+						NTPTimestamp: 0x0102030405060708,
+					},
+					&DLRRReportBlock{
+						XRHeader: XRHeader{
+							BlockType: DLRRReportBlockType,
+						},
+						Reports: []DLRRReport{
+							{
+								SSRC:   0x88888888,
+								LastRR: 0x12345678,
+								DLRR:   0x99999999,
+							},
+							{
+								SSRC:   0x09090909,
+								LastRR: 0x12345678,
+								DLRR:   0x99999999,
+							},
+							{
+								SSRC:   0x11223344,
+								LastRR: 0x12345678,
+								DLRR:   0x99999999,
+							},
+						},
+					},
+					&StatisticsSummaryReportBlock{
+						XRHeader{
+							BlockType: StatisticsSummaryReportBlockType,
+						},
+						true, true, true, ToHIPv4,
+						0xFEDCBA98,
+						0x1234, 0x5678,
+						0x11111111,
+						0x22222222,
+						0x33333333,
+						0x44444444,
+						0x55555555,
+						0x66666666,
+						0x01, 0x02, 0x03, 0x04,
+					},
+					&VoIPMetricsReportBlock{
+						XRHeader{
+							BlockType: VoIPMetricsReportBlockType,
+						},
+						0x89ABCDEF,
+						0x05, 0x06, 0x07, 0x08,
+						0x1111, 0x2222, 0x3333, 0x4444,
+						0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+						0x00,
+						0x1122, 0x3344, 0x5566,
+					},
+				},
+			},
+			"rtcp.ExtendedReport:\n" +
+				"\tSenderSSRC: 0x1020304\n" +
+				"\tReports:\n" +
+				"\t\t0 (rtcp.LossRLEReportBlock):\n" +
+				"\t\t\tXRHeader:\n" +
+				"\t\t\t\tBlockType: [LossRLEReportBlockType]\n" +
+				"\t\t\t\tTypeSpecific: 0x0\n" +
+				"\t\t\t\tBlockLength: 0\n" +
+				"\t\t\tT: 0\n" +
+				"\t\t\tSSRC: 0x12345689\n" +
+				"\t\t\tBeginSeq: 5\n" +
+				"\t\t\tEndSeq: 12\n" +
+				"\t\t\tChunks:\n" +
+				"\t\t\t\t0: [[RunLength type=1, length=6]]\n" +
+				"\t\t\t\t1: [[RunLength type=0, length=6]]\n" +
+				"\t\t\t\t2: [[BitVector 0b000011101100101]]\n" +
+				"\t\t\t\t3: [[TerminatingNull]]\n" +
+				"\t\t1 (rtcp.DuplicateRLEReportBlock):\n" +
+				"\t\t\tXRHeader:\n" +
+				"\t\t\t\tBlockType: [DuplicateRLEReportBlockType]\n" +
+				"\t\t\t\tTypeSpecific: 0x0\n" +
+				"\t\t\t\tBlockLength: 0\n" +
+				"\t\t\tT: 0\n" +
+				"\t\t\tSSRC: 0x12345689\n" +
+				"\t\t\tBeginSeq: 5\n" +
+				"\t\t\tEndSeq: 12\n" +
+				"\t\t\tChunks:\n" +
+				"\t\t\t\t0: [[RunLength type=1, length=291]]\n" +
+				"\t\t\t\t1: [[RunLength type=0, length=16383]]\n" +
+				"\t\t\t\t2: [[BitVector 0b111111111111111]]\n" +
+				"\t\t\t\t3: [[TerminatingNull]]\n" +
+				"\t\t2 (rtcp.PacketReceiptTimesReportBlock):\n" +
+				"\t\t\tXRHeader:\n" +
+				"\t\t\t\tBlockType: [PacketReceiptTimesReportBlockType]\n" +
+				"\t\t\t\tTypeSpecific: 0x0\n" +
+				"\t\t\t\tBlockLength: 0\n" +
+				"\t\t\tT: 0\n" +
+				"\t\t\tSSRC: 0x98765432\n" +
+				"\t\t\tBeginSeq: 15432\n" +
+				"\t\t\tEndSeq: 15577\n" +
+				"\t\t\tReceiptTime: [286331153 572662306 858993459 1145324612 1431655765]\n" +
+				"\t\t3 (rtcp.ReceiverReferenceTimeReportBlock):\n" +
+				"\t\t\tXRHeader:\n" +
+				"\t\t\t\tBlockType: [ReceiverReferenceTimeReportBlockType]\n" +
+				"\t\t\t\tTypeSpecific: 0x0\n" +
+				"\t\t\t\tBlockLength: 0\n" +
+				"\t\t\tNTPTimestamp: 72623859790382856\n" +
+				"\t\t4 (rtcp.DLRRReportBlock):\n" +
+				"\t\t\tXRHeader:\n" +
+				"\t\t\t\tBlockType: [DLRRReportBlockType]\n" +
+				"\t\t\t\tTypeSpecific: 0x0\n" +
+				"\t\t\t\tBlockLength: 0\n" +
+				"\t\t\tReports:\n" +
+				"\t\t\t\t0:\n" +
+				"\t\t\t\t\tSSRC: 0x88888888\n" +
+				"\t\t\t\t\tLastRR: 305419896\n" +
+				"\t\t\t\t\tDLRR: 2576980377\n" +
+				"\t\t\t\t1:\n" +
+				"\t\t\t\t\tSSRC: 0x9090909\n" +
+				"\t\t\t\t\tLastRR: 305419896\n" +
+				"\t\t\t\t\tDLRR: 2576980377\n" +
+				"\t\t\t\t2:\n" +
+				"\t\t\t\t\tSSRC: 0x11223344\n" +
+				"\t\t\t\t\tLastRR: 305419896\n" +
+				"\t\t\t\t\tDLRR: 2576980377\n" +
+				"\t\t5 (rtcp.StatisticsSummaryReportBlock):\n" +
+				"\t\t\tXRHeader:\n" +
+				"\t\t\t\tBlockType: [StatisticsSummaryReportBlockType]\n" +
+				"\t\t\t\tTypeSpecific: 0x0\n" +
+				"\t\t\t\tBlockLength: 0\n" +
+				"\t\t\tLossReports: true\n" +
+				"\t\t\tDuplicateReports: true\n" +
+				"\t\t\tJitterReports: true\n" +
+				"\t\t\tTTLorHopLimit: [[ToH = IPv4]]\n" +
+				"\t\t\tSSRC: 0xFEDCBA98\n" +
+				"\t\t\tBeginSeq: 4660\n" +
+				"\t\t\tEndSeq: 22136\n" +
+				"\t\t\tLostPackets: 286331153\n" +
+				"\t\t\tDupPackets: 572662306\n" +
+				"\t\t\tMinJitter: 858993459\n" +
+				"\t\t\tMaxJitter: 1145324612\n" +
+				"\t\t\tMeanJitter: 1431655765\n" +
+				"\t\t\tDevJitter: 1717986918\n" +
+				"\t\t\tMinTTLOrHL: 1\n" +
+				"\t\t\tMaxTTLOrHL: 2\n" +
+				"\t\t\tMeanTTLOrHL: 3\n" +
+				"\t\t\tDevTTLOrHL: 4\n" +
+				"\t\t6 (rtcp.VoIPMetricsReportBlock):\n" +
+				"\t\t\tXRHeader:\n" +
+				"\t\t\t\tBlockType: [VoIPMetricsReportBlockType]\n" +
+				"\t\t\t\tTypeSpecific: 0x0\n" +
+				"\t\t\t\tBlockLength: 0\n" +
+				"\t\t\tSSRC: 0x89ABCDEF\n" +
+				"\t\t\tLossRate: 5\n" +
+				"\t\t\tDiscardRate: 6\n" +
+				"\t\t\tBurstDensity: 7\n" +
+				"\t\t\tGapDensity: 8\n" +
+				"\t\t\tBurstDuration: 4369\n" +
+				"\t\t\tGapDuration: 8738\n" +
+				"\t\t\tRoundTripDelay: 13107\n" +
+				"\t\t\tEndSystemDelay: 17476\n" +
+				"\t\t\tSignalLevel: 17\n" +
+				"\t\t\tNoiseLevel: 34\n" +
+				"\t\t\tRERL: 51\n" +
+				"\t\t\tGmin: 68\n" +
+				"\t\t\tRFactor: 85\n" +
+				"\t\t\tExtRFactor: 102\n" +
+				"\t\t\tMOSLQ: 119\n" +
+				"\t\t\tMOSCQ: 136\n" +
+				"\t\t\tRXConfig: 153\n" +
+				"\t\t\tJBNominal: 4386\n" +
+				"\t\t\tJBMaximum: 13124\n" +
+				"\t\t\tJBAbsMax: 21862\n",
+		},
+		{
+			&FullIntraRequest{
+				SenderSSRC: 0x0,
+				MediaSSRC:  0x4bc4fcb4,
+				FIR: []FIREntry{
+					{
+						SSRC:           0x12345678,
+						SequenceNumber: 0x42,
+					},
+					{
+						SSRC:           0x98765432,
+						SequenceNumber: 0x57,
+					},
+				},
+			},
+			"rtcp.FullIntraRequest:\n" +
+				"\tSenderSSRC: 0\n" +
+				"\tMediaSSRC: 1271200948\n" +
+				"\tFIR:\n" +
+				"\t\t0:\n" +
+				"\t\t\tSSRC: 305419896\n" +
+				"\t\t\tSequenceNumber: 66\n" +
+				"\t\t1:\n" +
+				"\t\t\tSSRC: 2557891634\n" +
+				"\t\t\tSequenceNumber: 87\n",
+		},
+		{
+			&Goodbye{
+				Sources: []uint32{
+					0x01020304,
+					0x05060708,
+				},
+				Reason: "because",
+			},
+			"rtcp.Goodbye:\n" +
+				"\tSources: [16909060 84281096]\n" +
+				"\tReason: because\n",
+		},
+		{
+			&ReceiverReport{
+				SSRC: 0x902f9e2e,
+				Reports: []ReceptionReport{{
+					SSRC:               0xbc5e9a40,
+					FractionLost:       0,
+					TotalLost:          0,
+					LastSequenceNumber: 0x46e1,
+					Jitter:             273,
+					LastSenderReport:   0x9f36432,
+					Delay:              150137,
+				}},
+				ProfileExtensions: []byte{},
+			},
+			"rtcp.ReceiverReport:\n" +
+				"\tSSRC: 2419039790\n" +
+				"\tReports:\n" +
+				"\t\t0:\n" +
+				"\t\t\tSSRC: 3160316480\n" +
+				"\t\t\tFractionLost: 0\n" +
+				"\t\t\tTotalLost: 0\n" +
+				"\t\t\tLastSequenceNumber: 18145\n" +
+				"\t\t\tJitter: 273\n" +
+				"\t\t\tLastSenderReport: 166945842\n" +
+				"\t\t\tDelay: 150137\n" +
+				"\tProfileExtensions: []\n",
+		},
+		{
+			&SourceDescription{
+				Chunks: []SourceDescriptionChunk{
+					{
+						Source: 0x902f9e2e,
+						Items: []SourceDescriptionItem{
+							{
+								Type: SDESCNAME,
+								Text: "{9c00eb92-1afb-9d49-a47d-91f64eee69f5}",
+							},
+						},
+					},
+				},
+			},
+			"rtcp.SourceDescription:\n" +
+				"\tChunks:\n" +
+				"\t\t0:\n" +
+				"\t\t\tSource: 2419039790\n" +
+				"\t\t\tItems:\n" +
+				"\t\t\t\t0:\n" +
+				"\t\t\t\t\tType: [CNAME]\n" +
+				"\t\t\t\t\tText: {9c00eb92-1afb-9d49-a47d-91f64eee69f5}\n",
+		},
+		{
+			&PictureLossIndication{
+				SenderSSRC: 0x902f9e2e,
+				MediaSSRC:  0x902f9e2e,
+			},
+			"rtcp.PictureLossIndication:\n" +
+				"\tSenderSSRC: 2419039790\n" +
+				"\tMediaSSRC: 2419039790\n",
+		},
+		{
+			&RapidResynchronizationRequest{
+				SenderSSRC: 0x902f9e2e,
+				MediaSSRC:  0x902f9e2e,
+			},
+			"rtcp.RapidResynchronizationRequest:\n" +
+				"\tSenderSSRC: 2419039790\n" +
+				"\tMediaSSRC: 2419039790\n",
+		},
+		{
+			&ReceiverEstimatedMaximumBitrate{
+				SenderSSRC: 1,
+				Bitrate:    8927168,
+				SSRCs:      []uint32{1215622422},
+			},
+			"rtcp.ReceiverEstimatedMaximumBitrate:\n" +
+				"\tSenderSSRC: 1\n" +
+				"\tBitrate: 8.927168e+06\n" +
+				"\tSSRCs: [1215622422]\n",
+		},
+		{
+			&SenderReport{
+				SSRC:        0x902f9e2e,
+				NTPTime:     0xda8bd1fcdddda05a,
+				RTPTime:     0xaaf4edd5,
+				PacketCount: 1,
+				OctetCount:  2,
+				Reports: []ReceptionReport{{
+					SSRC:               0xbc5e9a40,
+					FractionLost:       0,
+					TotalLost:          0,
+					LastSequenceNumber: 0x46e1,
+					Jitter:             273,
+					LastSenderReport:   0x9f36432,
+					Delay:              150137,
+				}},
+				ProfileExtensions: []byte{
+					0x81, 0xca, 0x0, 0x6,
+					0x2b, 0x7e, 0xc0, 0xc5,
+					0x1, 0x10, 0x4c, 0x63,
+					0x49, 0x66, 0x7a, 0x58,
+					0x6f, 0x6e, 0x44, 0x6f,
+					0x72, 0x64, 0x53, 0x65,
+					0x57, 0x36, 0x0, 0x0,
+				},
+			},
+			"rtcp.SenderReport:\n" +
+				"\tSSRC: 2419039790\n" +
+				"\tNTPTime: 15747911406015324250\n" +
+				"\tRTPTime: 2868178389\n" +
+				"\tPacketCount: 1\n" +
+				"\tOctetCount: 2\n" +
+				"\tReports:\n" +
+				"\t\t0:\n" +
+				"\t\t\tSSRC: 3160316480\n" +
+				"\t\t\tFractionLost: 0\n" +
+				"\t\t\tTotalLost: 0\n" +
+				"\t\t\tLastSequenceNumber: 18145\n" +
+				"\t\t\tJitter: 273\n" +
+				"\t\t\tLastSenderReport: 166945842\n" +
+				"\t\t\tDelay: 150137\n" +
+				"\tProfileExtensions: [129 202 0 6 43 126 192 197 1 16 76 99 73 102 122 88 111 110 68 111 114 100 83 101 87 54 0 0]\n",
+		},
+		{
+			&SliceLossIndication{
+				SenderSSRC: 0x902f9e2e,
+				MediaSSRC:  0x902f9e2e,
+				SLI:        []SLIEntry{{0xaaa, 0, 0x2C}},
+			},
+			"rtcp.SliceLossIndication:\n" +
+				"\tSenderSSRC: 2419039790\n" +
+				"\tMediaSSRC: 2419039790\n" +
+				"\tSLI:\n" +
+				"\t\t0:\n" +
+				"\t\t\tFirst: 2730\n" +
+				"\t\t\tNumber: 0\n" +
+				"\t\t\tPicture: 44\n",
+		},
+		{
+			&SourceDescription{
+				Chunks: []SourceDescriptionChunk{
+					{
+						Source: 0x10000000,
+						Items: []SourceDescriptionItem{
+							{
+								Type: SDESCNAME,
+								Text: "A",
+							},
+							{
+								Type: SDESPhone,
+								Text: "B",
+							},
+						},
+					},
+				},
+			},
+			"rtcp.SourceDescription:\n" +
+				"\tChunks:\n" +
+				"\t\t0:\n" +
+				"\t\t\tSource: 268435456\n" +
+				"\t\t\tItems:\n" +
+				"\t\t\t\t0:\n" +
+				"\t\t\t\t\tType: [CNAME]\n" +
+				"\t\t\t\t\tText: A\n" +
+				"\t\t\t\t1:\n" +
+				"\t\t\t\t\tType: [PHONE]\n" +
+				"\t\t\t\t\tText: B\n",
+		},
+		{
+			&TransportLayerCC{
+				Header: Header{
+					Padding: true,
+					Count:   FormatTCC,
+					Type:    TypeTransportSpecificFeedback,
+					Length:  5,
+				},
+				SenderSSRC:         4195875351,
+				MediaSSRC:          1124282272,
+				BaseSequenceNumber: 153,
+				PacketStatusCount:  1,
+				ReferenceTime:      4057090,
+				FbPktCount:         23,
+				// 0b00100000, 0b00000001
+				PacketChunks: []PacketStatusChunk{
+					&RunLengthChunk{
+						Type:               TypeTCCRunLengthChunk,
+						PacketStatusSymbol: TypeTCCPacketReceivedSmallDelta,
+						RunLength:          1,
+					},
+				},
+				// 0b10010100
+				RecvDeltas: []*RecvDelta{
+					{
+						Type:  TypeTCCPacketReceivedSmallDelta,
+						Delta: 37000,
+					},
+				},
+			},
+			"rtcp.TransportLayerCC:\n" +
+				"\tHeader:\n" +
+				"\t\tPadding: true\n" +
+				"\t\tCount: 15\n" +
+				"\t\tType: [TSFB]\n" +
+				"\t\tLength: 5\n" +
+				"\tSenderSSRC: 4195875351\n" +
+				"\tMediaSSRC: 1124282272\n" +
+				"\tBaseSequenceNumber: 153\n" +
+				"\tPacketStatusCount: 1\n" +
+				"\tReferenceTime: 4057090\n" +
+				"\tFbPktCount: 23\n" +
+				"\tPacketChunks:\n" +
+				"\t\t0 (rtcp.RunLengthChunk):\n" +
+				"\t\t\tPacketStatusChunk: <nil>\n" +
+				"\t\t\tType: 0\n" +
+				"\t\t\tPacketStatusSymbol: 1\n" +
+				"\t\t\tRunLength: 1\n" +
+				"\tRecvDeltas:\n" +
+				"\t\t0:\n" +
+				"\t\t\tType: 1\n" +
+				"\t\t\tDelta: 37000\n",
+		},
+		{
+			&TransportLayerNack{
+				SenderSSRC: 0x902f9e2e,
+				MediaSSRC:  0x902f9e2e,
+				Nacks:      []NackPair{{1, 0xAA}, {1034, 0x05}},
+			},
+			"rtcp.TransportLayerNack:\n" +
+				"\tSenderSSRC: 2419039790\n" +
+				"\tMediaSSRC: 2419039790\n" +
+				"\tNacks:\n" +
+				"\t\t0:\n" +
+				"\t\t\tPacketID: 1\n" +
+				"\t\t\tLostPackets: 170\n" +
+				"\t\t1:\n" +
+				"\t\t\tPacketID: 1034\n" +
+				"\t\t\tLostPackets: 5\n",
+		},
+	}
+
+	for i, test := range tests {
+		actual := stringify(test.packet)
+		if actual != test.expected {
+			t.Fatalf("Error stringifying test %d\nExpected:\n%s\n\nGot:\n%s\n\n", i, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
#### Description
This patch adds baseline support for RTCP extended reports, as defined
in RFC 3611, including the baseline seven report block types it
describes. This patch also adds some introspection-based support
functions to provide semi-automated marshaling and unmarshaling of
arbitrary structures, and automated stringifying of Packet structures,
so as to greatly simplify adding the other 27 report types.

#### Reference issue
Fixes #8 