### PR TITLE
Removing `String()` method from `Packet` interface

### DIFF
--- a/compound_packet.go
+++ b/compound_packet.go
@@ -1,6 +1,7 @@
 package rtcp
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -140,7 +141,12 @@ func (c CompoundPacket) DestinationSSRC() []uint32 {
 func (c CompoundPacket) String() string {
 	out := "CompoundPacket\n"
 	for _, p := range c {
-		out += p.String()
+		stringer, canString := p.(fmt.Stringer)
+		if canString {
+			out += stringer.String()
+		} else {
+			out += stringify(p)
+		}
 	}
 	out = strings.TrimSuffix(strings.ReplaceAll(out, "\n", "\n\t"), "\t")
 	return out

--- a/extended_report_test.go
+++ b/extended_report_test.go
@@ -1,6 +1,7 @@
 package rtcp
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -255,7 +256,7 @@ func TestDecode(t *testing.T) {
 		t.Errorf("(deep equal) Decoded packet does not match expected packet")
 	}
 
-	if p.String() != expected.String() {
+	if p.String() != expected.(fmt.Stringer).String() {
 		t.Errorf("(string compare) Decoded packet does not match expected packet")
 	}
 }

--- a/packet.go
+++ b/packet.go
@@ -7,7 +7,6 @@ type Packet interface {
 
 	Marshal() ([]byte, error)
 	Unmarshal(rawPacket []byte) error
-	String() string
 }
 
 // Unmarshal takes an entire udp datagram (which may consist of multiple RTCP packets) and


### PR DESCRIPTION
#### Description
Per discussion on Slack, this patch undoes the addition
of a `String()` method on a Packet. Compound packets
now use the new `stringify()` function if a contained
Packet doesn't include a `String()` method.