### PR TITLE
Add NewCNAMESourceDescription helper method

### DIFF
--- a/compound_packet_test.go
+++ b/compound_packet_test.go
@@ -54,15 +54,7 @@ func TestBadCompound(t *testing.T) {
 }
 
 func TestValidPacket(t *testing.T) {
-	cname := &SourceDescription{
-		Chunks: []SourceDescriptionChunk{{
-			Source: 1234,
-			Items: []SourceDescriptionItem{{
-				Type: SDESCNAME,
-				Text: "cname",
-			}},
-		}},
-	}
+	cname := NewCNAMESourceDescription(1234, "cname")
 
 	for _, test := range []struct {
 		Name   string
@@ -147,15 +139,7 @@ func TestValidPacket(t *testing.T) {
 }
 
 func TestCNAME(t *testing.T) {
-	cname := &SourceDescription{
-		Chunks: []SourceDescriptionChunk{{
-			Source: 1234,
-			Items: []SourceDescriptionItem{{
-				Type: SDESCNAME,
-				Text: "cname",
-			}},
-		}},
-	}
+	cname := NewCNAMESourceDescription(1234, "cname")
 
 	for _, test := range []struct {
 		Name   string
@@ -241,15 +225,7 @@ func TestCNAME(t *testing.T) {
 }
 
 func TestCompoundPacketRoundTrip(t *testing.T) {
-	cname := &SourceDescription{
-		Chunks: []SourceDescriptionChunk{{
-			Source: 1234,
-			Items: []SourceDescriptionItem{{
-				Type: SDESCNAME,
-				Text: "cname",
-			}},
-		}},
-	}
+	cname := NewCNAMESourceDescription(1234, "cname")
 
 	for _, test := range []struct {
 		Name   string

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package rtcp

--- a/packet_stringifier_test.go
+++ b/packet_stringifier_test.go
@@ -294,19 +294,7 @@ func TestPrint(t *testing.T) {
 				"\tProfileExtensions: []\n",
 		},
 		{
-			&SourceDescription{
-				Chunks: []SourceDescriptionChunk{
-					{
-						Source: 0x902f9e2e,
-						Items: []SourceDescriptionItem{
-							{
-								Type: SDESCNAME,
-								Text: "{9c00eb92-1afb-9d49-a47d-91f64eee69f5}",
-							},
-						},
-					},
-				},
-			},
+			NewCNAMESourceDescription(0x902f9e2e, "{9c00eb92-1afb-9d49-a47d-91f64eee69f5}"),
 			"rtcp.SourceDescription:\n" +
 				"\tChunks:\n" +
 				"\t\t0:\n" +

--- a/packet_test.go
+++ b/packet_test.go
@@ -91,19 +91,7 @@ func TestUnmarshal(t *testing.T) {
 			}},
 			ProfileExtensions: []byte{},
 		},
-		&SourceDescription{
-			Chunks: []SourceDescriptionChunk{
-				{
-					Source: 0x902f9e2e,
-					Items: []SourceDescriptionItem{
-						{
-							Type: SDESCNAME,
-							Text: "{9c00eb92-1afb-9d49-a47d-91f64eee69f5}",
-						},
-					},
-				},
-			},
-		},
+		NewCNAMESourceDescription(0x902f9e2e, "{9c00eb92-1afb-9d49-a47d-91f64eee69f5}"),
 		&Goodbye{
 			Sources: []uint32{0x902f9e2e},
 		},

--- a/source_description.go
+++ b/source_description.go
@@ -61,6 +61,19 @@ type SourceDescription struct {
 	Chunks []SourceDescriptionChunk
 }
 
+// NewCNAMESourceDescription creates a new SourceDescription with a single CNAME item.
+func NewCNAMESourceDescription(ssrc uint32, cname string) *SourceDescription {
+	return &SourceDescription{
+		Chunks: []SourceDescriptionChunk{{
+			Source: ssrc,
+			Items: []SourceDescriptionItem{{
+				Type: SDESCNAME,
+				Text: cname,
+			}},
+		}},
+	}
+}
+
 // Marshal encodes the SourceDescription in binary
 func (s SourceDescription) Marshal() ([]byte, error) {
 	/*

--- a/source_description_test.go
+++ b/source_description_test.go
@@ -138,17 +138,7 @@ func TestSourceDescriptionUnmarshal(t *testing.T) {
 				// END + padding
 				0x00, 0x00,
 			},
-			Want: SourceDescription{
-				Chunks: []SourceDescriptionChunk{{
-					Source: 0x01020304,
-					Items: []SourceDescriptionItem{
-						{
-							Type: SDESCNAME,
-							Text: "",
-						},
-					},
-				}},
-			},
+			Want: *NewCNAMESourceDescription(0x01020304, ""),
 		},
 		{
 			Name: "two items",
@@ -321,15 +311,7 @@ func TestSourceDescriptionRoundTrip(t *testing.T) {
 		},
 		{
 			Name: "empty text",
-			Desc: SourceDescription{
-				Chunks: []SourceDescriptionChunk{{
-					Source: 1,
-					Items: []SourceDescriptionItem{{
-						Type: SDESCNAME,
-						Text: "",
-					}},
-				}},
-			},
+			Desc: *NewCNAMESourceDescription(1, ""),
 		},
 		{
 			Name: "text too long",


### PR DESCRIPTION
#### Description

This specific source description is very common. This change introduces
a helper method to simplify the creation of CNAME source descriptions.

#### Reference issue

One part of #22
