### PR TITLE
Add a type alias for RapidResynchronisationRequest

### DIFF
--- a/rapid_resynchronization_request.go
+++ b/rapid_resynchronization_request.go
@@ -14,6 +14,10 @@ type RapidResynchronizationRequest struct {
 	MediaSSRC uint32
 }
 
+// RapidResynchronisationRequest is provided as RFC 6051 spells resynchronization with an s.
+// We provide both names to be consistent with other RFCs which spell resynchronization with a z.
+type RapidResynchronisationRequest = RapidResynchronizationRequest
+
 const (
 	rrrLength       = 2
 	rrrHeaderLength = ssrcLength * 2


### PR DESCRIPTION
#### Description

RFC 6051 spells resynchronization with an s. This allows those
expecting the name to match the RFC to use the spelling they
would like.

#### Reference issue
Fixes #88
