### PR TITLE
Add MarshalSize() method to all packets

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -6,6 +6,7 @@
 Adam Roach <adam@caffeine.tv>
 adwpc <adwpc@hotmail.com>
 aggresss <aggresss@163.com>
+Alessandro Ros <aler9.dev@gmail.com>
 Atsushi Watanabe <atsushi.w@ieee.org>
 cnderrauber <zengjie9004@gmail.com>
 Gabor Pongracz <gabor.pongracz@proemergotech.com>

--- a/compound_packet.go
+++ b/compound_packet.go
@@ -97,6 +97,15 @@ func (c CompoundPacket) CNAME() (string, error) {
 	return "", errMissingCNAME
 }
 
+// MarshalSize returns the size of the packet once marshaled.
+func (c CompoundPacket) MarshalSize() int {
+	n := 0
+	for _, pkt := range c {
+		n += pkt.MarshalSize()
+	}
+	return n
+}
+
 // Marshal encodes the CompoundPacket as binary.
 func (c CompoundPacket) Marshal() ([]byte, error) {
 	if err := c.Validate(); err != nil {

--- a/extended_report.go
+++ b/extended_report.go
@@ -535,6 +535,11 @@ func (b *UnknownReportBlock) setupBlockHeader() {
 func (b *UnknownReportBlock) unpackBlockHeader() {
 }
 
+// MarshalSize returns the size of the packet once marshaled.
+func (x ExtendedReport) MarshalSize() int {
+	return headerLength + wireSize(x)
+}
+
 // Marshal encodes the ExtendedReport in binary
 func (x ExtendedReport) Marshal() ([]byte, error) {
 	for _, p := range x.Reports {

--- a/full_intra_request.go
+++ b/full_intra_request.go
@@ -27,9 +27,14 @@ const (
 
 var _ Packet = (*FullIntraRequest)(nil)
 
+// MarshalSize returns the size of the packet once marshaled.
+func (p FullIntraRequest) MarshalSize() int {
+	return headerLength + firOffset + len(p.FIR)*8
+}
+
 // Marshal encodes the FullIntraRequest
 func (p FullIntraRequest) Marshal() ([]byte, error) {
-	rawPacket := make([]byte, firOffset+(len(p.FIR)*8))
+	rawPacket := make([]byte, p.MarshalSize()-headerLength)
 	binary.BigEndian.PutUint32(rawPacket, p.SenderSSRC)
 	binary.BigEndian.PutUint32(rawPacket[4:], p.MediaSSRC)
 	for i, fir := range p.FIR {
@@ -80,12 +85,8 @@ func (p *FullIntraRequest) Header() Header {
 	return Header{
 		Count:  FormatFIR,
 		Type:   TypePayloadSpecificFeedback,
-		Length: uint16((p.len() / 4) - 1),
+		Length: uint16((p.MarshalSize() / 4) - 1),
 	}
-}
-
-func (p *FullIntraRequest) len() int {
-	return headerLength + firOffset + len(p.FIR)*8
 }
 
 func (p *FullIntraRequest) String() string {

--- a/packet.go
+++ b/packet.go
@@ -5,7 +5,13 @@ type Packet interface {
 	// DestinationSSRC returns an array of SSRC values that this packet refers to.
 	DestinationSSRC() []uint32
 
+	// MarshalSize returns the size of the packet once marshaled.
+	MarshalSize() int
+
+	// Marshal serializes the packet into bytes.
 	Marshal() ([]byte, error)
+
+	// Unmarshal deserializes the packet from bytes.
 	Unmarshal(rawPacket []byte) error
 }
 

--- a/picture_loss_indication.go
+++ b/picture_loss_indication.go
@@ -18,6 +18,11 @@ const (
 	pliLength = 2
 )
 
+// MarshalSize returns the size of the packet once marshaled.
+func (p PictureLossIndication) MarshalSize() int {
+	return headerLength + ssrcLength*2
+}
+
 // Marshal encodes the PictureLossIndication in binary
 func (p PictureLossIndication) Marshal() ([]byte, error) {
 	/*
@@ -26,7 +31,7 @@ func (p PictureLossIndication) Marshal() ([]byte, error) {
 	 *
 	 * The semantics of this FB message is independent of the payload type.
 	 */
-	rawPacket := make([]byte, p.len())
+	rawPacket := make([]byte, p.MarshalSize())
 	packetBody := rawPacket[headerLength:]
 
 	binary.BigEndian.PutUint32(packetBody, p.SenderSSRC)
@@ -73,10 +78,6 @@ func (p *PictureLossIndication) Header() Header {
 		Type:   TypePayloadSpecificFeedback,
 		Length: pliLength,
 	}
-}
-
-func (p *PictureLossIndication) len() int {
-	return headerLength + ssrcLength*2
 }
 
 func (p *PictureLossIndication) String() string {

--- a/rapid_resynchronization_request.go
+++ b/rapid_resynchronization_request.go
@@ -24,6 +24,11 @@ const (
 	rrrMediaOffset  = 4
 )
 
+// MarshalSize returns the size of the packet once marshaled.
+func (p RapidResynchronizationRequest) MarshalSize() int {
+	return headerLength + rrrHeaderLength
+}
+
 // Marshal encodes the RapidResynchronizationRequest in binary
 func (p RapidResynchronizationRequest) Marshal() ([]byte, error) {
 	/*
@@ -32,7 +37,7 @@ func (p RapidResynchronizationRequest) Marshal() ([]byte, error) {
 	 *
 	 * The semantics of this FB message is independent of the payload type.
 	 */
-	rawPacket := make([]byte, p.len())
+	rawPacket := make([]byte, p.MarshalSize())
 	packetBody := rawPacket[headerLength:]
 
 	binary.BigEndian.PutUint32(packetBody, p.SenderSSRC)
@@ -65,10 +70,6 @@ func (p *RapidResynchronizationRequest) Unmarshal(rawPacket []byte) error {
 	p.SenderSSRC = binary.BigEndian.Uint32(rawPacket[headerLength:])
 	p.MediaSSRC = binary.BigEndian.Uint32(rawPacket[headerLength+ssrcLength:])
 	return nil
-}
-
-func (p *RapidResynchronizationRequest) len() int {
-	return headerLength + rrrHeaderLength
 }
 
 // Header returns the Header associated with this packet.

--- a/raw_packet.go
+++ b/raw_packet.go
@@ -6,6 +6,11 @@ import "fmt"
 // a packet with an unknown type is encountered.
 type RawPacket []byte
 
+// MarshalSize returns the size of the packet once marshaled.
+func (r RawPacket) MarshalSize() int {
+	return len(r)
+}
+
 // Marshal encodes the packet in binary.
 func (r RawPacket) Marshal() ([]byte, error) {
 	return r, nil

--- a/receiver_estimated_maximum_bitrate.go
+++ b/receiver_estimated_maximum_bitrate.go
@@ -39,8 +39,7 @@ func (p ReceiverEstimatedMaximumBitrate) Marshal() (buf []byte, err error) {
 	return buf, nil
 }
 
-// MarshalSize returns the size of the packet when marshaled.
-// This can be used in conjunction with `MarshalTo` to avoid allocations.
+// MarshalSize returns the size of the packet once marshaled.
 func (p ReceiverEstimatedMaximumBitrate) MarshalSize() (n int) {
 	return 20 + 4*len(p.SSRCs)
 }

--- a/receiver_report.go
+++ b/receiver_report.go
@@ -25,6 +25,15 @@ const (
 	rrReportOffset = rrSSRCOffset + ssrcLength
 )
 
+// MarshalSize returns the size of the packet once marshaled.
+func (r ReceiverReport) MarshalSize() int {
+	repsLength := 0
+	for _, rep := range r.Reports {
+		repsLength += rep.len()
+	}
+	return headerLength + ssrcLength + repsLength
+}
+
 // Marshal encodes the ReceiverReport in binary
 func (r ReceiverReport) Marshal() ([]byte, error) {
 	/*
@@ -55,7 +64,7 @@ func (r ReceiverReport) Marshal() ([]byte, error) {
 	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 	 */
 
-	rawPacket := make([]byte, r.len())
+	rawPacket := make([]byte, r.MarshalSize())
 	packetBody := rawPacket[headerLength:]
 
 	binary.BigEndian.PutUint32(packetBody, r.SSRC)
@@ -154,20 +163,12 @@ func (r *ReceiverReport) Unmarshal(rawPacket []byte) error {
 	return nil
 }
 
-func (r *ReceiverReport) len() int {
-	repsLength := 0
-	for _, rep := range r.Reports {
-		repsLength += rep.len()
-	}
-	return headerLength + ssrcLength + repsLength
-}
-
 // Header returns the Header associated with this packet.
 func (r *ReceiverReport) Header() Header {
 	return Header{
 		Count:  uint8(len(r.Reports)),
 		Type:   TypeReceiverReport,
-		Length: uint16((r.len()/4)-1) + uint16(getPadding(len(r.ProfileExtensions))),
+		Length: uint16((r.MarshalSize()/4)-1) + uint16(getPadding(len(r.ProfileExtensions))),
 	}
 }
 

--- a/rfc8888.go
+++ b/rfc8888.go
@@ -88,13 +88,13 @@ func (b CCFeedbackReport) DestinationSSRC() []uint32 {
 	return ssrcs
 }
 
-// Len returns the length of the report in bytes
-func (b *CCFeedbackReport) Len() uint16 {
+// MarshalSize returns the size of the packet once marshaled.
+func (b CCFeedbackReport) MarshalSize() int {
 	n := uint16(0)
 	for _, block := range b.ReportBlocks {
 		n += block.len()
 	}
-	return reportBlockOffset + n + reportTimestampLength
+	return int(reportBlockOffset + n + reportTimestampLength)
 }
 
 // Header returns the Header associated with this packet.
@@ -103,7 +103,7 @@ func (b *CCFeedbackReport) Header() Header {
 		Padding: false,
 		Count:   FormatCCFB,
 		Type:    TypeTransportSpecificFeedback,
-		Length:  b.Len()/4 - 1,
+		Length:  uint16(b.MarshalSize()/4 - 1),
 	}
 }
 
@@ -114,8 +114,7 @@ func (b CCFeedbackReport) Marshal() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	length := 4 * (header.Length + 1)
-	buf := make([]byte, length)
+	buf := make([]byte, b.MarshalSize())
 	copy(buf[:headerLength], headerBuf)
 	binary.BigEndian.PutUint32(buf[headerLength:], b.SenderSSRC)
 	offset := uint16(reportBlockOffset)

--- a/sender_report.go
+++ b/sender_report.go
@@ -53,6 +53,15 @@ const (
 	srReportOffset      = srOctetCountOffset + srOctetCountLength
 )
 
+// MarshalSize returns the size of the packet once marshaled.
+func (r SenderReport) MarshalSize() int {
+	repsLength := 0
+	for _, rep := range r.Reports {
+		repsLength += rep.len()
+	}
+	return headerLength + srHeaderLength + repsLength + len(r.ProfileExtensions)
+}
+
 // Marshal encodes the SenderReport in binary
 func (r SenderReport) Marshal() ([]byte, error) {
 	/*
@@ -93,7 +102,7 @@ func (r SenderReport) Marshal() ([]byte, error) {
 	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 	 */
 
-	rawPacket := make([]byte, r.len())
+	rawPacket := make([]byte, r.MarshalSize())
 	packetBody := rawPacket[headerLength:]
 
 	binary.BigEndian.PutUint32(packetBody[srSSRCOffset:], r.SSRC)
@@ -225,20 +234,12 @@ func (r *SenderReport) DestinationSSRC() []uint32 {
 	return out
 }
 
-func (r *SenderReport) len() int {
-	repsLength := 0
-	for _, rep := range r.Reports {
-		repsLength += rep.len()
-	}
-	return headerLength + srHeaderLength + repsLength + len(r.ProfileExtensions)
-}
-
 // Header returns the Header associated with this packet.
 func (r *SenderReport) Header() Header {
 	return Header{
 		Count:  uint8(len(r.Reports)),
 		Type:   TypeSenderReport,
-		Length: uint16((r.len() / 4) - 1),
+		Length: uint16((r.MarshalSize() / 4) - 1),
 	}
 }
 

--- a/slice_loss_indication.go
+++ b/slice_loss_indication.go
@@ -35,13 +35,18 @@ const (
 	sliOffset = 8
 )
 
+// MarshalSize returns the size of the packet once marshaled.
+func (p SliceLossIndication) MarshalSize() int {
+	return headerLength + sliOffset + (len(p.SLI) * 4)
+}
+
 // Marshal encodes the SliceLossIndication in binary
 func (p SliceLossIndication) Marshal() ([]byte, error) {
 	if len(p.SLI)+sliLength > math.MaxUint8 {
 		return nil, errTooManyReports
 	}
 
-	rawPacket := make([]byte, sliOffset+(len(p.SLI)*4))
+	rawPacket := make([]byte, p.MarshalSize()-headerLength)
 	binary.BigEndian.PutUint32(rawPacket, p.SenderSSRC)
 	binary.BigEndian.PutUint32(rawPacket[4:], p.MediaSSRC)
 	for i, s := range p.SLI {
@@ -90,16 +95,12 @@ func (p *SliceLossIndication) Unmarshal(rawPacket []byte) error {
 	return nil
 }
 
-func (p *SliceLossIndication) len() int {
-	return headerLength + sliOffset + (len(p.SLI) * 4)
-}
-
 // Header returns the Header associated with this packet.
 func (p *SliceLossIndication) Header() Header {
 	return Header{
 		Count:  FormatSLI,
 		Type:   TypeTransportSpecificFeedback,
-		Length: uint16((p.len() / 4) - 1),
+		Length: uint16((p.MarshalSize() / 4) - 1),
 	}
 }
 

--- a/source_description.go
+++ b/source_description.go
@@ -74,6 +74,15 @@ func NewCNAMESourceDescription(ssrc uint32, cname string) *SourceDescription {
 	}
 }
 
+// MarshalSize returns the size of the packet once marshaled.
+func (s SourceDescription) MarshalSize() int {
+	chunksLength := 0
+	for _, c := range s.Chunks {
+		chunksLength += c.len()
+	}
+	return headerLength + chunksLength
+}
+
 // Marshal encodes the SourceDescription in binary
 func (s SourceDescription) Marshal() ([]byte, error) {
 	/*
@@ -94,7 +103,7 @@ func (s SourceDescription) Marshal() ([]byte, error) {
 	 *        +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
 	 */
 
-	rawPacket := make([]byte, s.len())
+	rawPacket := make([]byte, s.MarshalSize())
 	packetBody := rawPacket[headerLength:]
 
 	chunkOffset := 0
@@ -166,20 +175,12 @@ func (s *SourceDescription) Unmarshal(rawPacket []byte) error {
 	return nil
 }
 
-func (s *SourceDescription) len() int {
-	chunksLength := 0
-	for _, c := range s.Chunks {
-		chunksLength += c.len()
-	}
-	return headerLength + chunksLength
-}
-
 // Header returns the Header associated with this packet.
 func (s *SourceDescription) Header() Header {
 	return Header{
 		Count:  uint8(len(s.Chunks)),
 		Type:   TypeSourceDescription,
-		Length: uint16((s.len() / 4) - 1),
+		Length: uint16((s.MarshalSize() / 4) - 1),
 	}
 }
 


### PR DESCRIPTION
#### Description

This allows to get packet sizes without marshaling, a feature already
provided by pion/rtp in case of RTP packets. It replaces a lot of
functions that were implemented differently from packet to packet.

This is required in order to implement MarshalTo() and marshal packets
into pre-allocated byte slices, greatly improving performance.
