### PR TITLE
Discard padding bits in symbol status vector chunk

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -6,6 +6,7 @@
 Adam Roach <adam@caffeine.tv>
 adwpc <adwpc@hotmail.com>
 aggresss <aggresss@163.com>
+Anshul <malikanshul29@gmail.com>
 Atsushi Watanabe <atsushi.w@ieee.org>
 cnderrauber <zengjie9004@gmail.com>
 Gabor Pongracz <gabor.pongracz@proemergotech.com>

--- a/transport_layer_cc.go
+++ b/transport_layer_cc.go
@@ -501,21 +501,23 @@ func (t *TransportLayerCC) Unmarshal(rawPacket []byte) error { //nolint:gocognit
 			if err != nil {
 				return err
 			}
+
+			packetNumberToProcess := min(t.PacketStatusCount-processedPacketNum, uint16(len(packetStatus.SymbolList)))
 			if packetStatus.SymbolSize == TypeTCCSymbolSizeOneBit {
-				for j := 0; j < len(packetStatus.SymbolList); j++ {
+				for j := uint16(0); j < packetNumberToProcess; j++ {
 					if packetStatus.SymbolList[j] == TypeTCCPacketReceivedSmallDelta {
 						t.RecvDeltas = append(t.RecvDeltas, &RecvDelta{Type: TypeTCCPacketReceivedSmallDelta})
 					}
 				}
 			}
 			if packetStatus.SymbolSize == TypeTCCSymbolSizeTwoBit {
-				for j := 0; j < len(packetStatus.SymbolList); j++ {
+				for j := uint16(0); j < packetNumberToProcess; j++ {
 					if packetStatus.SymbolList[j] == TypeTCCPacketReceivedSmallDelta || packetStatus.SymbolList[j] == TypeTCCPacketReceivedLargeDelta {
 						t.RecvDeltas = append(t.RecvDeltas, &RecvDelta{Type: packetStatus.SymbolList[j]})
 					}
 				}
 			}
-			processedPacketNum += uint16(len(packetStatus.SymbolList))
+			processedPacketNum += packetNumberToProcess
 		}
 		packetStatusPos += packetStatusChunkLength
 		t.PacketChunks = append(t.PacketChunks, iPacketStatus)


### PR DESCRIPTION
If a status vector chunk is at the end of all the chunks, might be the case that not all of the bits represent packet status, we should check how many bits actually contain the status and how many are padding. 

Right now, we consider padding bits as lost packets, they should not be included in the `RecvDeltas`.

