### PR TITLE
Fix overflow in RFC8888

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -18,6 +18,7 @@ lllf <littlelightlittlefire@gmail.com>
 Luke Curley <kixelated@gmail.com>
 Mathis Engelbart <mathis.engelbart@gmail.com>
 Max Hawkins <maxhawkins@gmail.com>
+Sean <sean@siobud.com>
 Sean DuBois <seaduboi@amazon.com>
 Sean DuBois <sean@siobud.com>
 Simone Gotti <simone.gotti@gmail.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -11,6 +11,7 @@ cnderrauber <zengjie9004@gmail.com>
 Gabor Pongracz <gabor.pongracz@proemergotech.com>
 Hugo Arregui <hugo.arregui@gmail.com>
 Hugo Arregui <hugo@decentraland.org>
+Juho Nurminen <juhonurm@gmail.com>
 Juliusz Chroboczek <jch@irif.fr>
 Kevin Wang <kevmo314@gmail.com>
 lllf <littlelightlittlefire@gmail.com>
@@ -21,6 +22,8 @@ Sean DuBois <seaduboi@amazon.com>
 Sean DuBois <sean@siobud.com>
 Simone Gotti <simone.gotti@gmail.com>
 Steffen Vogel <post@steffenvogel.de>
+tanghao <tanghao1996.seu@gmail.com>
+tanghao <tanghao@bilibili.com>
 Woodrow Douglass <wdouglass@carnegierobotics.com>
 
 # List of contributors not appearing in Git history

--- a/rfc8888.go
+++ b/rfc8888.go
@@ -93,8 +93,8 @@ func (b CCFeedbackReport) DestinationSSRC() []uint32 {
 }
 
 // Len returns the length of the report in bytes
-func (b *CCFeedbackReport) Len() uint16 {
-	n := uint16(0)
+func (b *CCFeedbackReport) Len() int {
+	n := 0
 	for _, block := range b.ReportBlocks {
 		n += block.len()
 	}
@@ -107,7 +107,7 @@ func (b *CCFeedbackReport) Header() Header {
 		Padding: false,
 		Count:   FormatCCFB,
 		Type:    TypeTransportSpecificFeedback,
-		Length:  b.Len()/4 - 1,
+		Length:  uint16(b.Len()/4 - 1),
 	}
 }
 
@@ -122,7 +122,7 @@ func (b CCFeedbackReport) Marshal() ([]byte, error) {
 	buf := make([]byte, length)
 	copy(buf[:headerLength], headerBuf)
 	binary.BigEndian.PutUint32(buf[headerLength:], b.SenderSSRC)
-	offset := uint16(reportBlockOffset)
+	offset := reportBlockOffset
 	for _, block := range b.ReportBlocks {
 		b, err := block.marshal()
 		if err != nil {
@@ -164,10 +164,10 @@ func (b *CCFeedbackReport) Unmarshal(rawPacket []byte) error {
 
 	b.SenderSSRC = binary.BigEndian.Uint32(rawPacket[headerLength:])
 
-	reportTimestampOffset := uint16(len(rawPacket) - reportTimestampLength)
+	reportTimestampOffset := len(rawPacket) - reportTimestampLength
 	b.ReportTimestamp = binary.BigEndian.Uint32(rawPacket[reportTimestampOffset:])
 
-	offset := uint16(reportBlockOffset)
+	offset := reportBlockOffset
 	b.ReportBlocks = []CCFeedbackReportBlock{}
 	for offset < reportTimestampOffset {
 		var block CCFeedbackReportBlock
@@ -199,12 +199,12 @@ type CCFeedbackReportBlock struct {
 }
 
 // len returns the length of the report block in bytes
-func (b *CCFeedbackReportBlock) len() uint16 {
+func (b *CCFeedbackReportBlock) len() int {
 	n := len(b.MetricBlocks)
 	if n%2 != 0 {
 		n++
 	}
-	return reportsOffset + 2*uint16(n)
+	return reportsOffset + 2*n
 }
 
 func (b CCFeedbackReportBlock) String() string {
@@ -263,13 +263,14 @@ func (b *CCFeedbackReportBlock) unmarshal(rawPacket []byte) error {
 	}
 
 	endSequence := b.BeginSequence + numReportsField
-	numReports := endSequence - b.BeginSequence + 1
+	numReports := int(endSequence - b.BeginSequence + 1)
 
-	if len(rawPacket) < reportsOffset+int(numReports)*2 {
+	if len(rawPacket) < reportsOffset+numReports*2 {
 		return errIncorrectNumReports
 	}
+
 	b.MetricBlocks = make([]CCFeedbackMetricBlock, numReports)
-	for i := uint16(0); i < numReports; i++ {
+	for i := int(0); i < numReports; i++ {
 		var mb CCFeedbackMetricBlock
 		offset := reportsOffset + 2*i
 		if err := mb.unmarshal(rawPacket[offset : offset+2]); err != nil {


### PR DESCRIPTION
Use int instead of uint16. We assert that values on the wire can't be greater then math.MaxUint16, but when iterating we would overflow.

This changes everything to int and adds tests

Co-Authored-By: Juho Nurminen <juhonurm@gmail.com>