### PR TITLE
Reason is optional

### DIFF
--- a/goodbye.go
+++ b/goodbye.go
@@ -133,7 +133,11 @@ func (g *Goodbye) Header() Header {
 // MarshalSize returns the size of the packet once marshaled
 func (g *Goodbye) MarshalSize() int {
 	srcsLength := len(g.Sources) * ssrcLength
-	reasonLength := len(g.Reason) + 1
+	// reason is optional
+	reasonLength := len(g.Reason)
+	if reasonLength > 0 {
+		reasonLength++
+	}
 
 	l := headerLength + srcsLength + reasonLength
 


### PR DESCRIPTION
#### Description
If no reason, additional 4 bytes 0, which is not required.
eg:
81 CB 00 02 09 3A 89 2D 00 00 00 00

#### Reference issue
Fixes #...
