### PR TITLE
Update lint rules, force testify/assert

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,12 +20,16 @@ linters-settings:
             recommendations:
               - errors
   forbidigo:
+    analyze-types: true
     forbid:
       - ^fmt.Print(f|ln)?$
       - ^log.(Panic|Fatal|Print)(f|ln)?$
       - ^os.Exit$
       - ^panic$
       - ^print(ln)?$
+      - p: ^testing.T.(Error|Errorf|Fatal|Fatalf|Fail|FailNow)$
+        pkg: ^testing$
+        msg: "use testify/assert instead"
   varnamelen:
     max-distance: 12
     min-name-length: 2
@@ -128,9 +132,12 @@ issues:
   exclude-dirs-use-default: false
   exclude-rules:
     # Allow complex tests and examples, better to be self contained
-    - path: (examples|main\.go|_test\.go)
+    - path: (examples|main\.go)
       linters:
+        - gocognit
         - forbidigo
+    - path: _test\.go
+      linters:
         - gocognit
 
     # Allow forbidden identifiers in CLI commands

--- a/application_defined_test.go
+++ b/application_defined_test.go
@@ -4,9 +4,9 @@
 package rtcp
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTApplicationPacketUnmarshal(t *testing.T) {
@@ -128,27 +128,16 @@ func TestTApplicationPacketUnmarshal(t *testing.T) {
 	} {
 		var apk ApplicationDefined
 		err := apk.Unmarshal(test.Data)
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal %q result: got = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Unmarshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
-		if got, want := apk, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q result: got %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, apk, "Unmarshal %q", test.Name)
 
 		// Check SSRC is matching
-		if apk.SSRC != 0x4baae1ab {
-			t.Fatalf("SSRC %q result: got packet SSRC %x instead of %x", test.Name, apk.SSRC, 0x4baae1ab)
-		}
-		if apk.SSRC != apk.DestinationSSRC()[0] {
-			t.Fatalf(
-				"SSRC %q result: DestinationSSRC() %x doesn't match SSRC field %x",
-				test.Name, apk.DestinationSSRC()[0], apk.SSRC,
-			)
-		}
+		assert.Equalf(t, uint32(0x4baae1ab), apk.SSRC, "%q SSRC mismatch", test.Name)
+		assert.Equalf(t, uint32(0x4baae1ab), apk.DestinationSSRC()[0], "%q DestinationSSRC mismatch", test.Name)
 	}
 }
 
@@ -246,24 +235,14 @@ func TestTApplicationPacketMarshal(t *testing.T) {
 		},
 	} {
 		rawPacket, err := test.Packet.Marshal()
-
-		// Check for expected errors
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Marshal %q result: got = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Marshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
-		// Check for expected successful result
-		if got, want := rawPacket, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Marshal %q result: got %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, rawPacket, "Marshal %q", test.Name)
 
-		// Check if MarshalSize() is matching the marshaled  bytes
 		marshalSize := test.Packet.MarshalSize()
-		if marshalSize != len(rawPacket) {
-			t.Fatalf("MarshalSize %q result: got %d bytes instead of %d", test.Name, len(rawPacket), marshalSize)
-		}
+		assert.Equalf(t, marshalSize, len(rawPacket), "MarshalSize %q", test.Name)
 	}
 }

--- a/full_intra_request_test.go
+++ b/full_intra_request_test.go
@@ -4,9 +4,9 @@
 package rtcp
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFullIntraRequestUnmarshal(t *testing.T) {
@@ -141,16 +141,12 @@ func TestFullIntraRequestUnmarshal(t *testing.T) {
 	} {
 		var fir FullIntraRequest
 		err := fir.Unmarshal(test.Data)
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal %q rr: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Unmarshal %q rr mismatch", test.Name)
 		if err != nil {
 			continue
 		}
 
-		if got, want := fir, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q rr: got %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, fir, "Unmarshal %q rr mismatch", test.Name)
 	}
 }
 
@@ -184,21 +180,14 @@ func TestFullIntraRequestRoundTrip(t *testing.T) {
 		},
 	} {
 		data, err := test.Packet.Marshal()
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Marshal %q: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Marshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
 		var decoded FullIntraRequest
-		if err := decoded.Unmarshal(data); err != nil {
-			t.Fatalf("Unmarshal %q: %v", test.Name, err)
-		}
-
-		if got, want := decoded, test.Packet; !reflect.DeepEqual(got, want) {
-			t.Fatalf("%q rr round trip: got %#v, want %#v", test.Name, got, want)
-		}
+		assert.NoErrorf(t, decoded.Unmarshal(data), "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Packet, decoded, "%q rr header mismatch", test.Name)
 	}
 }
 
@@ -232,15 +221,11 @@ func TestFullIntraRequestUnmarshalHeader(t *testing.T) {
 	} {
 		var fir FullIntraRequest
 		err := fir.Unmarshal(test.Data)
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal header %q rr: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Unmarshal header %q rr mismatch", test.Name)
 		if err != nil {
 			continue
 		}
 
-		if got, want := fir.Header(), test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal header %q rr: got %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, fir.Header(), "Unmarshal header %q rr mismatch", test.Name)
 	}
 }

--- a/goodbye_test.go
+++ b/goodbye_test.go
@@ -4,9 +4,9 @@
 package rtcp
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var _ Packet = (*Goodbye)(nil) // assert is a Packet
@@ -113,16 +113,12 @@ func TestGoodbyeUnmarshal(t *testing.T) {
 	} {
 		var bye Goodbye
 		err := bye.Unmarshal(test.Data)
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal %q bye: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Unmarshal %q bye mismatch", test.Name)
 		if err != nil {
 			continue
 		}
 
-		if got, want := bye, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q bye: got %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, bye, "Unmarshal %q bye mismatch", test.Name)
 	}
 }
 
@@ -197,20 +193,13 @@ func TestGoodbyeRoundTrip(t *testing.T) {
 		},
 	} {
 		data, err := test.Bye.Marshal()
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Marshal %q: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Marshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
 		var bye Goodbye
-		if err := bye.Unmarshal(data); err != nil {
-			t.Fatalf("Unmarshal %q: %v", test.Name, err)
-		}
-
-		if got, want := bye, test.Bye; !reflect.DeepEqual(got, want) {
-			t.Fatalf("%q sdes round trip: got %#v, want %#v", test.Name, got, want)
-		}
+		assert.NoErrorf(t, bye.Unmarshal(data), "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Bye, bye, "%q bye round trip mismatch", test.Name)
 	}
 }

--- a/header_test.go
+++ b/header_test.go
@@ -4,9 +4,9 @@
 package rtcp
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHeaderUnmarshal(t *testing.T) {
@@ -53,16 +53,12 @@ func TestHeaderUnmarshal(t *testing.T) {
 	} {
 		var h Header
 		err := h.Unmarshal(test.Data)
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal %q header: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Unmarshal %q header mispmatch", test.Name)
 		if err != nil {
 			continue
 		}
 
-		if got, want := h, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q header: got %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, h, "Unmarshal %q header mismatch", test.Name)
 	}
 }
 
@@ -99,20 +95,13 @@ func TestHeaderRoundTrip(t *testing.T) {
 		},
 	} {
 		data, err := test.Header.Marshal()
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Errorf("Marshal %q: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Marshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
 		var decoded Header
-		if err := decoded.Unmarshal(data); err != nil {
-			t.Errorf("Unmarshal %q: %v", test.Name, err)
-		}
-
-		if got, want := decoded, test.Header; !reflect.DeepEqual(got, want) {
-			t.Errorf("%q header round trip: got %#v, want %#v", test.Name, got, want)
-		}
+		assert.NoErrorf(t, decoded.Unmarshal(data), "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Header, decoded, "%q header round trip mismatch", test.Name)
 	}
 }

--- a/packet_buffer_test.go
+++ b/packet_buffer_test.go
@@ -4,10 +4,9 @@
 package rtcp
 
 import (
-	"bytes"
-	"errors"
-	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWrite(t *testing.T) {
@@ -47,29 +46,19 @@ func TestWrite(t *testing.T) {
 		0x11, 0x22, 0x33, 0x44, 9, 8, 7, 6, 5, 4, 3, 2, 1,
 		0x00, 0x00, 0x00, 0x01, 1, 2, 3, 4, 0x00, 0x00, 0x00, 0x02, 5, 6, 7, 8,
 	}
-
-	size := wireSize(structure)
-	if size != len(expected) {
-		t.Fatalf("wireSize() returned unexpected value. Expected %v, got %v", len(expected), size)
-	}
+	assert.Equal(t, len(expected), wireSize(structure))
 
 	raw := make([]byte, len(expected))
 	buffer := packetBuffer{bytes: raw}
 	err := buffer.write(structure)
-	if err != nil {
-		t.Fatalf("Serialization failed. Err = %v", err)
-	}
-	if !bytes.Equal(raw, expected) {
-		t.Fatalf("Serialization failed. Wanted %v, got %v", expected, raw)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, expected, raw)
 
 	// Check for overflow
 	raw = make([]byte, len(expected)-1)
 	buffer = packetBuffer{bytes: raw}
 	err = buffer.write(structure)
-	if !errors.Is(err, errWrongMarshalSize) {
-		t.Fatalf("Serialization failed. Err = %v", err)
-	}
+	assert.ErrorIs(t, err, errWrongMarshalSize)
 }
 
 func TestReadUint8(t *testing.T) {
@@ -78,12 +67,8 @@ func TestReadUint8(t *testing.T) {
 	output := uint8(0)
 	buffer := packetBuffer{bytes: raw}
 	err := buffer.read(&output)
-	if err != nil {
-		t.Fatalf("Value parsing failed. Err = %v", err)
-	}
-	if output != expected {
-		t.Fatalf("Reading uint8 failed. Wanted %X, got %X", expected, output)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(expected), output)
 }
 
 func TestReadUint16(t *testing.T) {
@@ -92,12 +77,8 @@ func TestReadUint16(t *testing.T) {
 	output := uint16(0)
 	buffer := packetBuffer{bytes: raw}
 	err := buffer.read(&output)
-	if err != nil {
-		t.Fatalf("Value parsing failed. Err = %v", err)
-	}
-	if output != expected {
-		t.Fatalf("Reading uint16 failed. Wanted %X, got %X", expected, output)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, uint16(expected), output)
 }
 
 func TestReadUint32(t *testing.T) {
@@ -106,12 +87,8 @@ func TestReadUint32(t *testing.T) {
 	output := uint32(0)
 	buffer := packetBuffer{bytes: raw}
 	err := buffer.read(&output)
-	if err != nil {
-		t.Fatalf("Value parsing failed. Err = %v", err)
-	}
-	if output != expected {
-		t.Fatalf("Reading uint32 failed. Wanted %X, got %X", expected, output)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(expected), output)
 }
 
 func TestReadUint64(t *testing.T) {
@@ -120,12 +97,8 @@ func TestReadUint64(t *testing.T) {
 	output := uint64(0)
 	buffer := packetBuffer{bytes: raw}
 	err := buffer.read(&output)
-	if err != nil {
-		t.Fatalf("Value parsing failed. Err = %v", err)
-	}
-	if output != expected {
-		t.Fatalf("Reading uint64 failed. Wanted %X, got %X", expected, output)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, expected, output)
 }
 
 func TestReadStruct(t *testing.T) {
@@ -140,12 +113,8 @@ func TestReadStruct(t *testing.T) {
 	var output S
 	buffer := packetBuffer{bytes: raw}
 	err := buffer.read(&output)
-	if err != nil {
-		t.Fatalf("Struct parsing failed. Err = %v", err)
-	}
-	if output != expected {
-		t.Fatalf("Reading struct failed. Wanted %v, got %v", expected, output)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, expected, output)
 }
 
 func TestReadSlice(t *testing.T) {
@@ -154,12 +123,8 @@ func TestReadSlice(t *testing.T) {
 	var output []uint16
 	buffer := packetBuffer{bytes: raw}
 	err := buffer.read(&output)
-	if err != nil {
-		t.Fatalf("Slice parsing failed. Err = %v", err)
-	}
-	if fmt.Sprintf("%x", output) != fmt.Sprintf("%x", expected) {
-		t.Fatalf("Reading struct failed. Wanted %v, got %v", expected, output)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, expected, output)
 }
 
 func TestReadComplex(t *testing.T) {
@@ -202,10 +167,6 @@ func TestReadComplex(t *testing.T) {
 
 	buffer := packetBuffer{bytes: raw}
 	err := buffer.read(&output)
-	if err != nil {
-		t.Fatalf("Complex parsing failed. Err = %v", err)
-	}
-	if fmt.Sprintf("%x", output) != fmt.Sprintf("%x", expected) {
-		t.Fatalf("Reading struct failed. Wanted %v, got %v", expected, output)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, expected, output)
 }

--- a/packet_stringifier_test.go
+++ b/packet_stringifier_test.go
@@ -5,6 +5,8 @@ package rtcp
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 //nolint:maintidx
@@ -502,9 +504,6 @@ func TestPrint(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual := stringify(test.packet)
-		if actual != test.expected {
-			t.Fatalf("Error stringifying test %d\nExpected:\n%s\n\nGot:\n%s\n\n", i, test.expected, actual)
-		}
+		assert.Equalf(t, test.expected, stringify(test.packet), "Error stringifying test %d", i)
 	}
 }

--- a/packet_test.go
+++ b/packet_test.go
@@ -4,7 +4,6 @@
 package rtcp
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,9 +84,7 @@ func realPacket() []byte {
 
 func TestUnmarshal(t *testing.T) {
 	packet, err := Unmarshal(realPacket())
-	if err != nil {
-		t.Fatalf("Error unmarshalling packets: %s", err)
-	}
+	assert.NoError(t, err)
 
 	expected := []Packet{
 		&ReceiverReport{
@@ -127,9 +124,7 @@ func TestUnmarshal(t *testing.T) {
 
 func TestUnmarshalNil(t *testing.T) {
 	_, err := Unmarshal(nil)
-	if got, want := err, errInvalidHeader; !errors.Is(got, want) {
-		t.Fatalf("Unmarshal(nil) err = %v, want %v", got, want)
-	}
+	assert.ErrorIs(t, err, errInvalidHeader)
 }
 
 func TestInvalidHeaderLength(t *testing.T) {
@@ -140,7 +135,5 @@ func TestInvalidHeaderLength(t *testing.T) {
 	}
 
 	_, err := Unmarshal(invalidPacket)
-	if got, want := err, errPacketTooShort; !errors.Is(got, want) {
-		t.Fatalf("Unmarshal(nil) err = %v, want %v", got, want)
-	}
+	assert.ErrorIs(t, err, errPacketTooShort)
 }

--- a/picture_loss_indication_test.go
+++ b/picture_loss_indication_test.go
@@ -4,9 +4,9 @@
 package rtcp
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var _ Packet = (*PictureLossIndication)(nil) // assert is a Packet
@@ -76,16 +76,12 @@ func TestPictureLossIndicationUnmarshal(t *testing.T) {
 	} {
 		var pli PictureLossIndication
 		err := pli.Unmarshal(test.Data)
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal %q rr: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Unmarshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
-		if got, want := pli, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q rr: got %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, pli, "Unmarshal %q", test.Name)
 	}
 }
 
@@ -111,21 +107,14 @@ func TestPictureLossIndicationRoundTrip(t *testing.T) {
 		},
 	} {
 		data, err := test.Packet.Marshal()
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Marshal %q: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Marshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
 		var decoded PictureLossIndication
-		if err := decoded.Unmarshal(data); err != nil {
-			t.Fatalf("Unmarshal %q: %v", test.Name, err)
-		}
-
-		if got, want := decoded, test.Packet; !reflect.DeepEqual(got, want) {
-			t.Fatalf("%q rr round trip: got %#v, want %#v", test.Name, got, want)
-		}
+		assert.NoErrorf(t, decoded.Unmarshal(data), "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Packet, decoded, "%q rr round trip mismatch", test.Name)
 	}
 }
 
@@ -155,15 +144,11 @@ func TestPictureLossIndicationUnmarshalHeader(t *testing.T) {
 	} {
 		var pli PictureLossIndication
 		err := pli.Unmarshal(test.Data)
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal header %q rr: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Unmarshal header %q", test.Name)
 		if err != nil {
 			continue
 		}
 
-		if got, want := pli.Header(), test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal header %q rr: got %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, pli.Header(), "Unmarshal header %q", test.Name)
 	}
 }

--- a/rapid_resynchronization_request_test.go
+++ b/rapid_resynchronization_request_test.go
@@ -4,9 +4,9 @@
 package rtcp
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var _ Packet = (*RapidResynchronizationRequest)(nil) // assert is a Packet
@@ -73,16 +73,11 @@ func TestRapidResynchronizationRequestUnmarshal(t *testing.T) {
 	} {
 		var rrr RapidResynchronizationRequest
 		err := rrr.Unmarshal(test.Data)
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal %q rr: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Unmarshal %q", test.Name)
 		if err != nil {
 			continue
 		}
-
-		if got, want := rrr, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q rr: got %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, rrr, "Unmarshal %q", test.Name)
 	}
 }
 
@@ -101,20 +96,13 @@ func TestRapidResynchronizationRequestRoundTrip(t *testing.T) {
 		},
 	} {
 		data, err := test.Report.Marshal()
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Marshal %q: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Marshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
 		var decoded RapidResynchronizationRequest
-		if err := decoded.Unmarshal(data); err != nil {
-			t.Fatalf("Unmarshal %q: %v", test.Name, err)
-		}
-
-		if got, want := decoded, test.Report; !reflect.DeepEqual(got, want) {
-			t.Fatalf("%q rrr round trip: got %#v, want %#v", test.Name, got, want)
-		}
+		assert.NoErrorf(t, decoded.Unmarshal(data), "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Report, decoded, "%q round trip", test.Name)
 	}
 }

--- a/raw_packet_test.go
+++ b/raw_packet_test.go
@@ -4,9 +4,9 @@
 package rtcp
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var _ Packet = (*RawPacket)(nil) // assert is a Packet
@@ -44,24 +44,18 @@ func TestRawPacketRoundTrip(t *testing.T) {
 		},
 	} {
 		data, err := test.Packet.Marshal()
-		if got, want := err, test.WantMarshalError; !errors.Is(got, want) {
-			t.Fatalf("Marshal %q: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantMarshalError, "Marshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
 		var decoded RawPacket
+
 		err = decoded.Unmarshal(data)
-		if got, want := err, test.WantUnmarshalError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal %q: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantUnmarshalError, "Unmarshal %q", test.Name)
 		if err != nil {
 			continue
 		}
-
-		if got, want := decoded, test.Packet; !reflect.DeepEqual(got, want) {
-			t.Fatalf("%q raw round trip: got %#v, want %#v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Packet, decoded, "Unmarshal %q", test.Name)
 	}
 }

--- a/receiver_report_test.go
+++ b/receiver_report_test.go
@@ -4,9 +4,9 @@
 package rtcp
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var _ Packet = (*ReceiverReport)(nil) // assert is a Packet
@@ -157,16 +157,12 @@ func TestReceiverReportUnmarshal(t *testing.T) {
 	} {
 		var rr ReceiverReport
 		err := rr.Unmarshal(test.Data)
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal %q rr: err = %#v, want %#v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Unmarshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
-		if got, want := rr, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q rr: got %#v, want %#v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, rr, "Unmarshal %q", test.Name)
 	}
 }
 
@@ -253,20 +249,13 @@ func TestReceiverReportRoundTrip(t *testing.T) {
 		},
 	} {
 		data, err := test.Report.Marshal()
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Marshal %q: err = %#v, want %#v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Marshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
 		var decoded ReceiverReport
-		if err := decoded.Unmarshal(data); err != nil {
-			t.Fatalf("Unmarshal %q: %#v", test.Name, err)
-		}
-
-		if got, want := decoded, test.Report; !reflect.DeepEqual(got, want) {
-			t.Fatalf("%q rr round trip: got %#v, want %#v", test.Name, got, want)
-		}
+		assert.NoErrorf(t, decoded.Unmarshal(data), "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Report, decoded, "%s rr round trip mismatch", test.Name)
 	}
 }

--- a/sender_report_test.go
+++ b/sender_report_test.go
@@ -4,9 +4,9 @@
 package rtcp
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var _ Packet = (*SenderReport)(nil) // assert is a Packet
@@ -177,16 +177,11 @@ func TestSenderReportUnmarshal(t *testing.T) {
 	} {
 		var sr SenderReport
 		err := sr.Unmarshal(test.Data)
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal %q sr: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Unmarshal %q sr", test.Name)
 		if err != nil {
 			continue
 		}
-
-		if got, want := sr, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q sr: got %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, sr, "Unmarshal %q sr", test.Name)
 
 		var ssrcFound bool
 		dstSsrc := sr.DestinationSSRC()
@@ -198,9 +193,7 @@ func TestSenderReportUnmarshal(t *testing.T) {
 			}
 		}
 
-		if !ssrcFound {
-			t.Fatalf("Unmarshal %q sr: sr's DestinationSSRC should include it's SSRC field", test.Name)
-		}
+		assert.Truef(t, ssrcFound, "Unmarshal %q sr: sr's DestinationSSRC should include it's SSRC field", test.Name)
 	}
 }
 
@@ -279,20 +272,13 @@ func TestSenderReportRoundTrip(t *testing.T) {
 		},
 	} {
 		data, err := test.Report.Marshal()
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Marshal %q: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Marshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
 		var decoded SenderReport
-		if err := decoded.Unmarshal(data); err != nil {
-			t.Fatalf("Unmarshal %q: %v", test.Name, err)
-		}
-
-		if got, want := decoded, test.Report; !reflect.DeepEqual(got, want) {
-			t.Fatalf("%q sr round trip: got %#v, want %#v", test.Name, got, want)
-		}
+		assert.NoErrorf(t, decoded.Unmarshal(data), "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Report, decoded, "%q sr round trip", test.Name)
 	}
 }

--- a/slice_loss_indication_test.go
+++ b/slice_loss_indication_test.go
@@ -4,9 +4,9 @@
 package rtcp
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var _ Packet = (*SliceLossIndication)(nil) // assert is a Packet
@@ -76,16 +76,12 @@ func TestSliceLossIndicationUnmarshal(t *testing.T) {
 	} {
 		var sli SliceLossIndication
 		err := sli.Unmarshal(test.Data)
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal %q rr: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Unmarshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
-		if got, want := sli, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q rr: got %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, sli, "Unmarshal %q rr", test.Name)
 	}
 }
 
@@ -105,20 +101,13 @@ func TestSliceLossIndicationRoundTrip(t *testing.T) {
 		},
 	} {
 		data, err := test.Report.Marshal()
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Marshal %q: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Marshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
 		var decoded SliceLossIndication
-		if err := decoded.Unmarshal(data); err != nil {
-			t.Fatalf("Unmarshal %q: %v", test.Name, err)
-		}
-
-		if got, want := decoded, test.Report; !reflect.DeepEqual(got, want) {
-			t.Fatalf("%q sli round trip: got %#v, want %#v", test.Name, got, want)
-		}
+		assert.NoErrorf(t, decoded.Unmarshal(data), "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Report, decoded, "%q sli round trip mismatch", test.Name)
 	}
 }

--- a/source_description_test.go
+++ b/source_description_test.go
@@ -4,9 +4,9 @@
 package rtcp
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var _ Packet = (*SourceDescription)(nil) // assert is a Packet
@@ -221,16 +221,8 @@ func TestSourceDescriptionUnmarshal(t *testing.T) {
 	} {
 		var sdes SourceDescription
 		err := sdes.Unmarshal(test.Data)
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Unmarshal %q: err = %v, want %v", test.Name, got, want)
-		}
-		if err != nil {
-			continue
-		}
-
-		if got, want := sdes, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q: got %#v, want %#v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Want, sdes, "Unmarshal %q", test.Name)
 	}
 }
 
@@ -337,20 +329,13 @@ func TestSourceDescriptionRoundTrip(t *testing.T) {
 		},
 	} {
 		data, err := test.Desc.Marshal()
-		if got, want := err, test.WantError; !errors.Is(got, want) {
-			t.Fatalf("Marshal %q: err = %v, want %v", test.Name, got, want)
-		}
+		assert.ErrorIsf(t, err, test.WantError, "Marshal %q", test.Name)
 		if err != nil {
 			continue
 		}
 
 		var decoded SourceDescription
-		if err := decoded.Unmarshal(data); err != nil {
-			t.Fatalf("Unmarshal %q: %v", test.Name, err)
-		}
-
-		if got, want := decoded, test.Desc; !reflect.DeepEqual(got, want) {
-			t.Fatalf("%q sdes round trip: got %#v, want %#v", test.Name, got, want)
-		}
+		assert.NoErrorf(t, decoded.Unmarshal(data), "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Desc, decoded, "%s sdes round trip mismatch", test.Name)
 	}
 }

--- a/transport_layer_cc_test.go
+++ b/transport_layer_cc_test.go
@@ -4,9 +4,9 @@
 package rtcp
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var _ Packet = (*TransportLayerCC)(nil) // assert is a Packet
@@ -42,13 +42,8 @@ func TestTransportLayerCC_RunLengthChunkUnmarshal(t *testing.T) {
 		},
 	} {
 		var chunk RunLengthChunk
-		err := chunk.Unmarshal(test.Data)
-		if err != nil {
-			t.Fatalf("Unmarshal err: %v", err)
-		}
-		if got, want := chunk, test.Want; got != want {
-			t.Fatalf("Unmarshal %q : got = %v, want %v", test.Name, got, want)
-		}
+		assert.NoError(t, chunk.Unmarshal(test.Data))
+		assert.Equalf(t, test.Want, chunk, "Unmarshal %q", test.Name)
 	}
 }
 
@@ -84,9 +79,7 @@ func TestTransportLayerCC_RunLengthChunkMarshal(t *testing.T) {
 	} {
 		chunk := test.Data
 		data, _ := chunk.Marshal()
-		if got, want := data, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q : got = %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, data, "Marshal %q", test.Name)
 	}
 }
 
@@ -144,15 +137,10 @@ func TestTransportLayerCC_StatusVectorChunkUnmarshal(t *testing.T) {
 		},
 	} {
 		var chunk StatusVectorChunk
-		err := chunk.Unmarshal(test.Data)
-		if err != nil {
-			t.Fatalf("Unmarshal err: %v", err)
-		}
-
-		if got, want := chunk, test.Want; got.Type != want.Type ||
-			got.SymbolSize != want.SymbolSize || !reflect.DeepEqual(got.SymbolList, want.SymbolList) {
-			t.Fatalf("Unmarshal %q : got = %v, want %v", test.Name, got, want)
-		}
+		assert.NoErrorf(t, chunk.Unmarshal(test.Data), "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Want.Type, chunk.Type, "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Want.SymbolSize, chunk.SymbolSize, "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Want.SymbolList, chunk.SymbolList, "Unmarshal %q", test.Name)
 	}
 }
 
@@ -211,9 +199,7 @@ func TestTransportLayerCC_StatusVectorChunkMarshal(t *testing.T) {
 	} {
 		chunk := test.Data
 		data, _ := chunk.Marshal()
-		if got, want := data, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q : got = %v, want %v", test.Name, got, want)
-		}
+		assert.Equal(t, test.Want, data, "Unmarshal %q", test.Name)
 	}
 }
 
@@ -256,14 +242,8 @@ func TestTransportLayerCC_RecvDeltaUnmarshal(t *testing.T) {
 		},
 	} {
 		var chunk RecvDelta
-		err := chunk.Unmarshal(test.Data)
-		if err != nil {
-			t.Fatalf("Unmarshal err: %v", err)
-		}
-
-		if got, want := chunk, test.Want; got != want {
-			t.Fatalf("Unmarshal %q : got = %v, want %v", test.Name, got, want)
-		}
+		assert.NoErrorf(t, chunk.Unmarshal(test.Data), "Unmarshal %q", test.Name)
+		assert.Equalf(t, test.Want, chunk, "Unmarshal %q", test.Name)
 	}
 }
 
@@ -307,9 +287,7 @@ func TestTransportLayerCC_RecvDeltaMarshal(t *testing.T) {
 	} {
 		chunk := test.Data
 		data, _ := chunk.Marshal()
-		if got, want := data, test.Want; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Unmarshal %q : got = %v, want %v", test.Name, got, want)
-		}
+		assert.Equalf(t, test.Want, data, "Unmarshal %q", test.Name)
 	}
 }
 
@@ -779,16 +757,11 @@ func TestTransportLayerCC_Unmarshal(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			var chunk TransportLayerCC
 			err := chunk.Unmarshal(test.Data)
-			if got, want := err, test.WantError; !errors.Is(got, want) {
-				t.Fatalf("Unmarshal %q : err = %v, want %v", test.Name, got, want)
-			}
+			assert.ErrorIsf(t, err, test.WantError, "Unmarshal %q", test.Name)
 			if err != nil {
 				return
 			}
-
-			if got, want := chunk, test.Want; !reflect.DeepEqual(got, want) {
-				t.Fatalf("Unmarshal %q : got = %v, want %v", test.Name, got, want)
-			}
+			assert.Equalf(t, test.Want, chunk, "Unmarshal %q", test.Name)
 		})
 	}
 }
@@ -1189,12 +1162,8 @@ func TestTransportLayerCC_Marshal(t *testing.T) {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {
 			bin, err := test.Data.Marshal()
-			if err != nil {
-				t.Fatalf("Marshal err: %v", err)
-			}
-			if got, want := bin, test.Want; !reflect.DeepEqual(got, want) {
-				t.Fatalf("Marshal %q : got = %v, want %v", test.Name, got, want)
-			}
+			assert.NoError(t, err)
+			assert.Equalf(t, test.Want, bin, "Marshal %q", test.Name)
 		})
 	}
 }

--- a/util_test.go
+++ b/util_test.go
@@ -65,15 +65,11 @@ func TestSetNBitsOfUint16(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := setNBitsOfUint16(test.source, test.size, test.index, test.value)
 			if err != nil {
-				if err.Error() != test.err {
-					t.Fatalf("setNBitsOfUint16 %q : got = %v, want %v", test.name, err, test.err)
-				}
+				assert.Equalf(t, test.err, err.Error(), "setNBitsOfUint16 %q : got = %v, want %v", test.name, err, test.err)
 
 				return
 			}
-			if got != test.result {
-				t.Fatalf("setNBitsOfUint16 %q : got = %v, want %v", test.name, got, test.result)
-			}
+			assert.Equalf(t, test.result, got, "setNBitsOfUint16 %q : got = %v, want %v", test.name, got, test.result)
 		})
 	}
 }


### PR DESCRIPTION
#### Description

Update lint rules to forbid the use of direct testing.T helpers.

#### Reference issue

pion/.goassets/pull/222
